### PR TITLE
Remove duplicated code - Closes #34

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ npm-debug.log*
 .tmp
 .tmp-state
 .vscode
+.idea
 *.log
 tmp-state
 bin-package


### PR DESCRIPTION
### What was the problem?

This PR resolves #34

### How was it solved?

Duplicated code in `smt.rs` was replaced with a function calls.

### How was it tested?

All tests passed.