### PR TITLE
Replace Vec<u8> -> &[u8] - Closes #36

### DIFF
--- a/src/diff.rs
+++ b/src/diff.rs
@@ -22,7 +22,7 @@ impl KeyValue {
     }
 
     pub fn decode(val: Vec<u8>) -> Result<Self, codec::CodecError> {
-        let mut reader = codec::Reader::new(val);
+        let mut reader = codec::Reader::new(&val);
         let key = reader.read_bytes(1)?;
         let value = reader.read_bytes(2)?;
         Ok(Self { key, value })
@@ -46,7 +46,7 @@ impl Diff {
     }
 
     pub fn decode(val: Vec<u8>) -> Result<Self, codec::CodecError> {
-        let mut reader = codec::Reader::new(val);
+        let mut reader = codec::Reader::new(&val);
         let created = reader.read_bytes_slice(1)?;
         let updated_bytes = reader.read_bytes_slice(2)?;
         let mut updated = vec![];

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -17,12 +17,15 @@ pub struct Diff {
 }
 
 impl KeyValue {
-    pub fn new(key: Vec<u8>, value: Vec<u8>) -> Self {
-        Self { key, value }
+    pub fn new(key: &[u8], value: &[u8]) -> Self {
+        Self {
+            key: key.to_vec(),
+            value: value.to_vec(),
+        }
     }
 
-    pub fn decode(val: Vec<u8>) -> Result<Self, codec::CodecError> {
-        let mut reader = codec::Reader::new(&val);
+    pub fn decode(val: &[u8]) -> Result<Self, codec::CodecError> {
+        let mut reader = codec::Reader::new(val);
         let key = reader.read_bytes(1)?;
         let value = reader.read_bytes(2)?;
         Ok(Self { key, value })
@@ -45,19 +48,19 @@ impl Diff {
         }
     }
 
-    pub fn decode(val: Vec<u8>) -> Result<Self, codec::CodecError> {
-        let mut reader = codec::Reader::new(&val);
+    pub fn decode(val: &[u8]) -> Result<Self, codec::CodecError> {
+        let mut reader = codec::Reader::new(val);
         let created = reader.read_bytes_slice(1)?;
         let updated_bytes = reader.read_bytes_slice(2)?;
         let mut updated = vec![];
         for value in updated_bytes.iter() {
-            let kv = KeyValue::decode(value.to_vec())?;
+            let kv = KeyValue::decode(value)?;
             updated.push(kv);
         }
         let deleted_bytes = reader.read_bytes_slice(3)?;
         let mut deleted = vec![];
         for value in deleted_bytes.iter() {
-            let kv = KeyValue::decode(value.to_vec())?;
+            let kv = KeyValue::decode(value)?;
             deleted.push(kv);
         }
         Ok(Self {

--- a/src/in_memory_smt.rs
+++ b/src/in_memory_smt.rs
@@ -124,7 +124,7 @@ impl JsFunctionContext<'_> {
             let mut tree =
                 SparseMerkleTree::new(state_root, inner_smt.key_length, consts::SUBTREE_SIZE);
 
-            let result = tree.prove(&mut inner_smt.db, data);
+            let result = tree.prove(&mut inner_smt.db, &data);
 
             channel.send(move |mut ctx| {
                 let callback = callback.into_inner(&mut ctx);

--- a/src/in_memory_smt.rs
+++ b/src/in_memory_smt.rs
@@ -75,7 +75,7 @@ impl JsFunctionContext<'_> {
             let mut inner_smt = in_memory_smt.lock().unwrap();
 
             let mut tree =
-                SparseMerkleTree::new(state_root, inner_smt.key_length, consts::SUBTREE_SIZE);
+                SparseMerkleTree::new(&state_root, inner_smt.key_length, consts::SUBTREE_SIZE);
 
             let result = tree.commit(&mut inner_smt.db, &mut update_data);
 
@@ -122,7 +122,7 @@ impl JsFunctionContext<'_> {
         thread::spawn(move || {
             let mut inner_smt = in_memory_smt.lock().unwrap();
             let mut tree =
-                SparseMerkleTree::new(state_root, inner_smt.key_length, consts::SUBTREE_SIZE);
+                SparseMerkleTree::new(&state_root, inner_smt.key_length, consts::SUBTREE_SIZE);
 
             let result = tree.prove(&mut inner_smt.db, &data);
 

--- a/src/smt.rs
+++ b/src/smt.rs
@@ -1343,14 +1343,14 @@ impl SparseMerkleTree {
         Ok(self.root.clone())
     }
 
-    pub fn prove(&mut self, db: &mut impl DB, queries: Vec<Vec<u8>>) -> Result<Proof, SMTError> {
+    pub fn prove(&mut self, db: &mut impl DB, queries: &[Vec<u8>]) -> Result<Proof, SMTError> {
         if queries.is_empty() {
             return Ok(Proof {
                 queries: vec![],
                 sibling_hashes: vec![],
             });
         }
-        let (mut query_with_proofs, ancestor_hashes) = self.sibling_data(db, &queries)?;
+        let (mut query_with_proofs, ancestor_hashes) = self.sibling_data(db, queries)?;
         let proof_queries = self.proof_queries(&query_with_proofs);
 
         query_with_proofs.sort_descending();
@@ -1781,7 +1781,10 @@ mod tests {
             let proof = tree
                 .prove(
                     &mut db,
-                    query_keys.iter().map(|k| hex::decode(k).unwrap()).collect(),
+                    &query_keys
+                        .iter()
+                        .map(|k| hex::decode(k).unwrap())
+                        .collect::<Vec<Vec<u8>>>(),
                 )
                 .unwrap();
             for (i, query) in proof.queries.iter().enumerate() {
@@ -2028,7 +2031,10 @@ mod tests {
             let proof = tree
                 .prove(
                     &mut db,
-                    query_keys.iter().map(|k| hex::decode(k).unwrap()).collect(),
+                    &query_keys
+                        .iter()
+                        .map(|k| hex::decode(k).unwrap())
+                        .collect::<Vec<Vec<u8>>>(),
                 )
                 .unwrap();
             for (i, query) in proof.queries.iter().enumerate() {

--- a/src/smt.rs
+++ b/src/smt.rs
@@ -14,16 +14,16 @@ static PREFIX_LEAF_HASH: &[u8] = &[0];
 static PREFIX_BRANCH_HASH: &[u8] = &[1];
 static PREFIX_EMPTY: &[u8] = &[2];
 
-type Hasher = fn(node_hashes: &Vec<Vec<u8>>, structure: &[u8], height: usize) -> Vec<u8>;
+type Hasher = fn(node_hashes: &[Vec<u8>], structure: &[u8], height: usize) -> Vec<u8>;
 
 trait SortDescending {
     fn sort_descending(&mut self);
 }
 
 pub trait DB {
-    fn get(&self, key: Vec<u8>) -> Result<Option<Vec<u8>>, rocksdb::Error>;
-    fn set(&mut self, key: Vec<u8>, value: Vec<u8>) -> Result<(), rocksdb::Error>;
-    fn del(&mut self, key: Vec<u8>) -> Result<(), rocksdb::Error>;
+    fn get(&self, key: &[u8]) -> Result<Option<Vec<u8>>, rocksdb::Error>;
+    fn set(&mut self, key: &[u8], value: &[u8]) -> Result<(), rocksdb::Error>;
+    fn del(&mut self, key: &[u8]) -> Result<(), rocksdb::Error>;
 }
 
 #[derive(Error, Debug)]
@@ -114,7 +114,7 @@ struct QueryHashesRefMut<'a> {
 }
 
 struct QueryHashesInfo<'a> {
-    layer_nodes: &'a Vec<Node>,
+    layer_nodes: &'a [Node],
     layer_structure: &'a [u8],
     ref_mut_vecs: QueryHashesRefMut<'a>,
     extra: QueryHashesExtraInfo,
@@ -155,19 +155,19 @@ pub struct SparseMerkleTree {
 }
 
 fn key_hash(key: &[u8]) -> Vec<u8> {
-    let prefix = key[..PREFIX_SIZE].to_vec();
-    let body = key[PREFIX_SIZE..].to_vec();
+    let prefix = &key[..PREFIX_SIZE];
+    let body = &key[PREFIX_SIZE..];
     let mut hasher = Sha256::new();
     hasher.update(body);
     let result = hasher.finalize();
-    return [prefix, result.as_slice().to_vec()].concat();
+    [prefix, result.as_slice()].concat()
 }
 
 fn value_hash(value: &[u8]) -> Vec<u8> {
     let mut hasher = Sha256::new();
     hasher.update(value);
     let result = hasher.finalize();
-    return result.as_slice().to_vec();
+    result.to_vec()
 }
 
 fn leaf_hash(key: &[u8], value: &[u8]) -> Vec<u8> {
@@ -176,7 +176,7 @@ fn leaf_hash(key: &[u8], value: &[u8]) -> Vec<u8> {
     hasher.update(key);
     hasher.update(value);
     let result = hasher.finalize();
-    return result.as_slice().to_vec();
+    result.to_vec()
 }
 
 fn branch_hash(node_hash: &[u8]) -> Vec<u8> {
@@ -184,16 +184,16 @@ fn branch_hash(node_hash: &[u8]) -> Vec<u8> {
     hasher.update(PREFIX_BRANCH_HASH);
     hasher.update(node_hash);
     let result = hasher.finalize();
-    return result.as_slice().to_vec();
+    result.to_vec()
 }
 
 fn empty_hash() -> Vec<u8> {
     let hasher = Sha256::new();
     let result = hasher.finalize();
-    return result.as_slice().to_vec();
+    result.to_vec()
 }
 
-fn tree_hasher(node_hashes: &Vec<Vec<u8>>, structure: &[u8], height: usize) -> Vec<u8> {
+fn tree_hasher(node_hashes: &[Vec<u8>], structure: &[u8], height: usize) -> Vec<u8> {
     if node_hashes.len() == 1 {
         return node_hashes[0].clone();
     }
@@ -204,7 +204,7 @@ fn tree_hasher(node_hashes: &Vec<Vec<u8>>, structure: &[u8], height: usize) -> V
     while i < node_hashes.len() {
         if structure[i] == height as u8 {
             let branch = [node_hashes[i].clone(), node_hashes[i + 1].clone()].concat();
-            let hash = branch_hash(branch.as_slice());
+            let hash = branch_hash(&branch);
             next_hashes.push(hash);
             next_structure.push(structure[i] - 1);
             i += 1;
@@ -264,14 +264,14 @@ fn parent_node(
 }
 
 fn calculate_subtree(
-    layer_nodes: &Vec<Node>,
+    layer_nodes: &[Node],
     layer_structure: &[u8],
     height: u8,
     tree_map: &mut VecDeque<(Vec<Node>, Vec<u8>)>,
     hasher: Hasher,
 ) -> Result<SubTree, SMTError> {
     if height == 0 {
-        return SubTree::from_data(vec![0], layer_nodes.clone(), hasher);
+        return SubTree::from_data(&[0], layer_nodes, hasher);
     }
     let mut next_layer_nodes: Vec<Node> = vec![];
     let mut next_layer_structure: Vec<u8> = vec![];
@@ -295,9 +295,9 @@ fn calculate_subtree(
             let (nodes, structure) = tree_map
                 .pop_front()
                 .ok_or_else(|| SMTError::Unknown(String::from("Subtree must exist for stub")))?;
-            return SubTree::from_data(structure, nodes, hasher);
+            return SubTree::from_data(&structure, &nodes, hasher);
         }
-        return SubTree::from_data(vec![0], next_layer_nodes, hasher);
+        return SubTree::from_data(&[0], &next_layer_nodes, hasher);
     }
     calculate_subtree(
         &next_layer_nodes,
@@ -396,7 +396,7 @@ fn insert_and_filter_queries(q: QueryProofWithProof, queries: &mut VecDeque<Quer
 
 fn calculate_sibling_hashes(
     query_with_proofs: &mut VecDeque<QueryProofWithProof>,
-    ancestor_hashes: &Vec<Vec<u8>>,
+    ancestor_hashes: &[Vec<u8>],
     sibling_hashes: &mut Vec<Vec<u8>>,
 ) {
     if query_with_proofs.is_empty() {
@@ -487,7 +487,7 @@ impl UpdateData {
 impl QueryProofWithProof {
     fn new(
         key: &[u8],
-        value: &Vec<u8>,
+        value: &[u8],
         binary_bitmap: &[bool],
         ancestor_hashes: &[Vec<u8>],
         sibling_hashes: &[Vec<u8>],
@@ -499,7 +499,7 @@ impl QueryProofWithProof {
         };
         Self {
             key: key.to_vec(),
-            value: value.clone(),
+            value: value.to_vec(),
             binary_bitmap: binary_bitmap.to_vec(),
             bitmap: utils::bools_to_bytes(binary_bitmap),
             ancestor_hashes: ancestor_hashes.to_vec(),
@@ -613,34 +613,31 @@ impl Node {
 }
 
 impl SubTree {
-    pub fn new(data: Vec<u8>, key_length: usize, hasher: Hasher) -> Result<Self, SMTError> {
+    pub fn new(data: &[u8], key_length: usize, hasher: Hasher) -> Result<Self, SMTError> {
         if data.is_empty() {
             return Err(SMTError::InvalidInput(String::from("keys length is zero")));
         }
         let node_length: usize = data[0] as usize + 1;
-        let structure = data[1..node_length + 1].to_vec();
-        let node_data = data[node_length + 1..].to_vec();
+        let structure = &data[1..node_length + 1];
+        let node_data = &data[node_length + 1..];
         let mut nodes = vec![];
         let mut idx = 0;
 
         while idx < node_data.len() {
             match node_data[idx] {
                 PREFIX_INT_LEAF_HASH => {
-                    let key = node_data
-                        [idx + PREFIX_LEAF_HASH.len()..idx + PREFIX_LEAF_HASH.len() + key_length]
-                        .to_vec();
-                    let value = node_data[idx + PREFIX_LEAF_HASH.len() + key_length
-                        ..idx + PREFIX_LEAF_HASH.len() + key_length + HASH_SIZE]
-                        .to_vec();
-                    let node = Node::new_leaf(key.as_slice(), value.as_slice());
+                    let key = &node_data
+                        [idx + PREFIX_LEAF_HASH.len()..idx + PREFIX_LEAF_HASH.len() + key_length];
+                    let value = &node_data[idx + PREFIX_LEAF_HASH.len() + key_length
+                        ..idx + PREFIX_LEAF_HASH.len() + key_length + HASH_SIZE];
+                    let node = Node::new_leaf(key, value);
                     nodes.push(node);
                     idx += PREFIX_LEAF_HASH.len() + key_length + HASH_SIZE;
                 },
                 PREFIX_INT_BRANCH_HASH => {
-                    let node_hash = node_data[idx + PREFIX_BRANCH_HASH.len()
-                        ..idx + PREFIX_BRANCH_HASH.len() + HASH_SIZE]
-                        .to_vec();
-                    nodes.push(Node::new_stub(node_hash.as_slice()));
+                    let node_hash = &node_data[idx + PREFIX_BRANCH_HASH.len()
+                        ..idx + PREFIX_BRANCH_HASH.len() + HASH_SIZE];
+                    nodes.push(Node::new_stub(node_hash));
                     idx += PREFIX_BRANCH_HASH.len() + HASH_SIZE;
                 },
                 PREFIX_INT_EMPTY => {
@@ -655,25 +652,24 @@ impl SubTree {
             }
         }
 
-        SubTree::from_data(structure, nodes, hasher)
+        SubTree::from_data(structure, &nodes, hasher)
     }
 
-    pub fn from_data(
-        structure: Vec<u8>,
-        nodes: Vec<Node>,
-        hasher: Hasher,
-    ) -> Result<Self, SMTError> {
+    pub fn from_data(structure: &[u8], nodes: &[Node], hasher: Hasher) -> Result<Self, SMTError> {
         let height = structure
             .iter()
             .max()
             .ok_or_else(|| SMTError::Unknown(String::from("Invalid structure")))?;
 
-        let node_hashes = nodes.iter().map(|n| n.hash.clone()).collect();
-        let calculated = hasher(&node_hashes, &structure, *height as usize);
+        let node_hashes = nodes
+            .iter()
+            .map(|n| n.hash.clone())
+            .collect::<Vec<Vec<u8>>>();
+        let calculated = hasher(&node_hashes, structure, *height as usize);
 
         Ok(Self {
-            structure,
-            nodes,
+            structure: structure.to_vec(),
+            nodes: nodes.to_vec(),
             root: calculated,
         })
     }
@@ -714,7 +710,7 @@ impl QueryHashesExtraInfo {
 
 impl<'a> QueryHashesInfo<'a> {
     fn new(
-        layer_nodes: &'a Vec<Node>,
+        layer_nodes: &'a [Node],
         layer_structure: &'a [u8],
         vecs: QueryHashesRefMut<'a>,
         extra: QueryHashesExtraInfo,
@@ -792,8 +788,7 @@ impl SparseMerkleTree {
         let root = self.get_subtree(db, &self.root)?;
         let mut ancestor_hashes = vec![];
         for query in queries {
-            let query_proof =
-                self.generate_query_proof(db, &mut root.clone(), query.to_vec(), 0)?;
+            let query_proof = self.generate_query_proof(db, &mut root.clone(), query, 0)?;
             query_with_proofs.push(query_proof.clone());
             ancestor_hashes.extend(query_proof.ancestor_hashes);
         }
@@ -847,11 +842,11 @@ impl SparseMerkleTree {
         }
 
         let value = db
-            .get(node_hash.clone())
+            .get(node_hash)
             .map_err(|err| SMTError::Unknown(err.to_string()))?
             .ok_or_else(|| SMTError::NotFound(String::from("node_hash does not exist")))?;
 
-        SubTree::new(value, self.key_length, self.hasher)
+        SubTree::new(&value, self.key_length, self.hasher)
     }
 
     fn calc_bins(
@@ -905,8 +900,8 @@ impl SparseMerkleTree {
             let current_node = current_subtree.nodes[i].clone();
             let new_offset = 1 << (self.subtree_height - h as usize);
 
-            let slice_keys = bins.keys[bin_offset..bin_offset + new_offset].to_vec();
-            let slice_values = bins.values[bin_offset..bin_offset + new_offset].to_vec();
+            let slice_keys = &bins.keys[bin_offset..bin_offset + new_offset];
+            let slice_values = &bins.values[bin_offset..bin_offset + new_offset];
             let mut sum = 0;
             let base_length: Vec<u32> = slice_keys
                 .iter()
@@ -917,8 +912,8 @@ impl SparseMerkleTree {
                 .collect();
 
             let info = UpdateNodeInfo::new(
-                &slice_keys,
-                &slice_values,
+                slice_keys,
+                slice_values,
                 &base_length,
                 current_node,
                 0,
@@ -942,15 +937,15 @@ impl SparseMerkleTree {
     fn update_subtree(
         &mut self,
         db: &mut impl DB,
-        key_bin: Vec<Vec<u8>>,
-        value_bin: Vec<Vec<u8>>,
+        key_bin: &[Vec<u8>],
+        value_bin: &[Vec<u8>],
         current_subtree: &SubTree,
         height: u32,
     ) -> Result<SubTree, SMTError> {
         if key_bin.is_empty() {
             return Ok(current_subtree.clone());
         }
-        let updated = self.calc_updated_info(db, current_subtree, &key_bin, &value_bin, height)?;
+        let updated = self.calc_updated_info(db, current_subtree, key_bin, value_bin, height)?;
         if updated.bin_offset != self.max_number_of_nodes {
             return Err(SMTError::Unknown(format!(
                 "bin_offset {} expected {}",
@@ -973,7 +968,7 @@ impl SparseMerkleTree {
             self.hasher,
         )?;
         let value = new_subtree.encode();
-        db.set(new_subtree.root.clone(), value)
+        db.set(&new_subtree.root, &value)
             .map_err(|err| SMTError::Unknown(err.to_string()))?;
 
         Ok(new_subtree)
@@ -988,10 +983,7 @@ impl SparseMerkleTree {
 
         if info.current_node.kind == NodeKind::Empty {
             if !info.value_bins[idx][0].is_empty() {
-                let new_leaf = Node::new_leaf(
-                    info.key_bins[idx][0].as_slice(),
-                    info.value_bins[idx][0].as_slice(),
-                );
+                let new_leaf = Node::new_leaf(&info.key_bins[idx][0], &info.value_bins[idx][0]);
                 return Ok((vec![new_leaf], vec![info.h]));
             }
             return Ok((vec![info.current_node.clone()], vec![info.h]));
@@ -1001,10 +993,7 @@ impl SparseMerkleTree {
             && utils::is_bytes_equal(&info.current_node.key, &info.key_bins[idx][0])
         {
             if !info.value_bins[idx][0].is_empty() {
-                let new_leaf = Node::new_leaf(
-                    info.key_bins[idx][0].as_slice(),
-                    info.value_bins[idx][0].as_slice(),
-                );
+                let new_leaf = Node::new_leaf(&info.key_bins[idx][0], &info.value_bins[idx][0]);
                 return Ok((vec![new_leaf], vec![info.h]));
             }
             return Ok((vec![Node::new_empty()], vec![info.h]));
@@ -1021,14 +1010,12 @@ impl SparseMerkleTree {
         let btm_subtree = match info.current_node.kind {
             NodeKind::Stub => {
                 let subtree = self.get_subtree(db, &info.current_node.hash)?;
-                db.del(info.current_node.hash.clone())
+                db.del(&info.current_node.hash)
                     .map_err(|err| SMTError::Unknown(err.to_string()))?;
                 subtree
             },
             NodeKind::Empty => self.get_subtree(db, &info.current_node.hash)?,
-            NodeKind::Leaf => {
-                SubTree::from_data(vec![0], vec![info.current_node.clone()], self.hasher)?
-            },
+            NodeKind::Leaf => SubTree::from_data(&[0], &[info.current_node.clone()], self.hasher)?,
             _ => {
                 return Err(SMTError::Unknown(String::from("invalid node type")));
             },
@@ -1038,15 +1025,15 @@ impl SparseMerkleTree {
         }
         let new_subtree = self.update_subtree(
             db,
-            info.key_bins[0].clone(),
-            info.value_bins[0].clone(),
+            &info.key_bins[0],
+            &info.value_bins[0],
             &btm_subtree,
             info.height + info.h as u32,
         )?;
         if new_subtree.nodes.len() == 1 {
             return Ok((vec![new_subtree.nodes[0].clone()], vec![info.h]));
         }
-        let new_branch = Node::new_stub(new_subtree.root.as_slice());
+        let new_branch = Node::new_stub(&new_subtree.root);
 
         Ok((vec![new_branch], vec![info.h]))
     }
@@ -1056,7 +1043,7 @@ impl SparseMerkleTree {
             NodeKind::Empty => Ok((Node::new_empty(), Node::new_empty())),
             NodeKind::Leaf => {
                 if utils::is_bit_set(
-                    info.current_node.key.as_slice(),
+                    &info.current_node.key,
                     (info.height + info.h as u32) as usize,
                 ) {
                     Ok((Node::new_empty(), info.current_node.clone()))
@@ -1165,7 +1152,7 @@ impl SparseMerkleTree {
         if d.current_node.kind == NodeKind::Empty {
             return Ok(QueryProofWithProof::new(
                 d.query_key,
-                &vec![],
+                &[],
                 d.ref_mut_vecs.binary_bitmap,
                 &Vec::from(ancestor_hashes),
                 &(sibling_hashes),
@@ -1177,7 +1164,7 @@ impl SparseMerkleTree {
             return Ok(QueryProofWithProof::new(
                 &d.current_node.key,
                 // 0 index is the leaf prefix
-                &d.current_node.data[PREFIX_LEAF_HASH.len() + HASH_SIZE..].to_vec(),
+                &d.current_node.data[PREFIX_LEAF_HASH.len() + HASH_SIZE..],
                 &binary_bitmap,
                 &Vec::from(ancestor_hashes),
                 &sibling_hashes,
@@ -1188,7 +1175,7 @@ impl SparseMerkleTree {
         let lower_query_proof = self.generate_query_proof(
             db,
             &mut lower_subtree,
-            d.query_key.to_vec(),
+            d.query_key,
             d.height + d.query_height,
         )?;
 
@@ -1228,7 +1215,7 @@ impl SparseMerkleTree {
         &mut self,
         db: &mut impl DB,
         current_subtree: &mut SubTree,
-        query_key: Vec<u8>,
+        query_key: &[u8],
         height: usize,
     ) -> Result<QueryProofWithProof, SMTError> {
         if query_key.len() != self.key_length {
@@ -1242,7 +1229,7 @@ impl SparseMerkleTree {
         }
 
         let (current_node, query_height) =
-            self.find_current_node(current_subtree, &query_key, height)?;
+            self.find_current_node(current_subtree, query_key, height)?;
 
         let mut ancestor_hashes = VecDeque::new();
         let mut sibling_hashes = VecDeque::new();
@@ -1260,7 +1247,7 @@ impl SparseMerkleTree {
         );
         calculate_query_hashes(info);
         let data = GenerateResultData {
-            query_key: &query_key,
+            query_key,
             current_node: &current_node,
             ref_mut_vecs: QueryHashesRefMut {
                 ancestor_hashes: &mut ancestor_hashes,
@@ -1312,12 +1299,12 @@ impl SparseMerkleTree {
         vec![]
     }
 
-    pub fn new(root: Vec<u8>, key_length: usize, subtree_height: usize) -> Self {
+    pub fn new(root: &[u8], key_length: usize, subtree_height: usize) -> Self {
         let max_number_of_nodes = 1 << subtree_height;
         let r = if root.is_empty() {
             utils::empty_hash()
         } else {
-            root
+            root.to_vec()
         };
         Self {
             root: r,
@@ -1338,7 +1325,7 @@ impl SparseMerkleTree {
         }
         let (update_keys, update_values) = data.entries();
         let root = self.get_subtree(db, &self.root)?;
-        let new_root = self.update_subtree(db, update_keys, update_values, &root, 0)?;
+        let new_root = self.update_subtree(db, &update_keys, &update_values, &root, 0)?;
         self.root = new_root.root;
         Ok(self.root.clone())
     }
@@ -1370,7 +1357,7 @@ impl SparseMerkleTree {
     }
 
     pub fn verify(
-        query_keys: &Vec<Vec<u8>>,
+        query_keys: &[Vec<u8>],
         proof: &Proof,
         root: &[u8],
         key_length: usize,
@@ -1410,7 +1397,7 @@ mod tests {
 
         for (data, hash, structure) in test_data {
             let decoded_data = hex::decode(data).unwrap();
-            let tree = SubTree::new(decoded_data, 32, tree_hasher).unwrap();
+            let tree = SubTree::new(&decoded_data, 32, tree_hasher).unwrap();
             let decoded_hash = hex::decode(hash).unwrap();
             assert_eq!(tree.structure, structure);
             assert_eq!(tree.root, decoded_hash);
@@ -1426,14 +1413,14 @@ mod tests {
 
         for (data, _, _) in test_data {
             let decoded_data = hex::decode(data).unwrap();
-            let tree = SubTree::new(decoded_data.clone(), 32, tree_hasher).unwrap();
+            let tree = SubTree::new(&decoded_data, 32, tree_hasher).unwrap();
             assert_eq!(tree.encode(), decoded_data.clone());
         }
     }
 
     #[test]
     fn test_empty_tree() {
-        let mut tree = SparseMerkleTree::new(vec![], 32, 8);
+        let mut tree = SparseMerkleTree::new(&[], 32, 8);
         let mut data = UpdateData {
             data: HashMap::new(),
         };
@@ -1456,7 +1443,7 @@ mod tests {
         )];
 
         for (keys, values, root) in test_data {
-            let mut tree = SparseMerkleTree::new(vec![], 32, 8);
+            let mut tree = SparseMerkleTree::new(&[], 32, 8);
             let mut data = UpdateData {
                 data: HashMap::new(),
             };
@@ -1488,7 +1475,7 @@ mod tests {
         )];
 
         for (keys, values, root) in test_data {
-            let mut tree = SparseMerkleTree::new(vec![], 32, 8);
+            let mut tree = SparseMerkleTree::new(&[], 32, 8);
             let mut data = UpdateData {
                 data: HashMap::new(),
             };
@@ -1528,7 +1515,7 @@ mod tests {
         )];
 
         for (keys, values, root) in test_data {
-            let mut tree = SparseMerkleTree::new(vec![], 32, 8);
+            let mut tree = SparseMerkleTree::new(&[], 32, 8);
             let mut data = UpdateData {
                 data: HashMap::new(),
             };
@@ -1576,7 +1563,7 @@ mod tests {
         )];
 
         for (keys, values, root) in test_data {
-            let mut tree = SparseMerkleTree::new(vec![], 32, 8);
+            let mut tree = SparseMerkleTree::new(&[], 32, 8);
             let mut data = UpdateData {
                 data: HashMap::new(),
             };
@@ -1763,7 +1750,7 @@ mod tests {
         ];
 
         for (keys, values, root, query_keys, sibling_hashes, queries) in test_data {
-            let mut tree = SparseMerkleTree::new(vec![], 32, 8);
+            let mut tree = SparseMerkleTree::new(&[], 32, 8);
             let mut data = UpdateData {
                 data: HashMap::new(),
             };
@@ -1801,7 +1788,10 @@ mod tests {
                 sibling_hashes
             );
             assert!(SparseMerkleTree::verify(
-                &query_keys.iter().map(|k| hex::decode(k).unwrap()).collect(),
+                &query_keys
+                    .iter()
+                    .map(|k| hex::decode(k).unwrap())
+                    .collect::<Vec<Vec<u8>>>(),
                 &proof,
                 &result,
                 32
@@ -2013,7 +2003,7 @@ mod tests {
         )];
 
         for (keys, values, root, query_keys, sibling_hashes, queries) in test_data {
-            let mut tree = SparseMerkleTree::new(vec![], 32, 8);
+            let mut tree = SparseMerkleTree::new(&[], 32, 8);
             let mut data = UpdateData {
                 data: HashMap::new(),
             };
@@ -2051,7 +2041,10 @@ mod tests {
                 sibling_hashes
             );
             assert!(SparseMerkleTree::verify(
-                &query_keys.iter().map(|k| hex::decode(k).unwrap()).collect(),
+                &query_keys
+                    .iter()
+                    .map(|k| hex::decode(k).unwrap())
+                    .collect::<Vec<Vec<u8>>>(),
                 &proof,
                 &result,
                 32

--- a/src/smt_db.rs
+++ b/src/smt_db.rs
@@ -13,17 +13,17 @@ pub struct InMemorySmtDB {
 }
 
 impl smt::DB for SmtDB<'_> {
-    fn get(&self, key: Vec<u8>) -> Result<Option<Vec<u8>>, rocksdb::Error> {
-        let result = self.db.get([consts::PREFIX_SMT, key.as_slice()].concat())?;
+    fn get(&self, key: &[u8]) -> Result<Option<Vec<u8>>, rocksdb::Error> {
+        let result = self.db.get([consts::PREFIX_SMT, key].concat())?;
         Ok(result)
     }
 
-    fn set(&mut self, key: Vec<u8>, value: Vec<u8>) -> Result<(), rocksdb::Error> {
+    fn set(&mut self, key: &[u8], value: &[u8]) -> Result<(), rocksdb::Error> {
         self.batch.put(key, value);
         Ok(())
     }
 
-    fn del(&mut self, key: Vec<u8>) -> Result<(), rocksdb::Error> {
+    fn del(&mut self, key: &[u8]) -> Result<(), rocksdb::Error> {
         self.batch.delete(key);
         Ok(())
     }
@@ -39,21 +39,21 @@ impl<'a> SmtDB<'a> {
 }
 
 impl smt::DB for InMemorySmtDB {
-    fn get(&self, key: Vec<u8>) -> Result<Option<Vec<u8>>, rocksdb::Error> {
-        let result = self.cache.get(&key);
+    fn get(&self, key: &[u8]) -> Result<Option<Vec<u8>>, rocksdb::Error> {
+        let result = self.cache.get(key);
         if let Some(value) = result {
             return Ok(Some(value.clone()));
         }
         Ok(None)
     }
 
-    fn set(&mut self, key: Vec<u8>, value: Vec<u8>) -> Result<(), rocksdb::Error> {
-        self.cache.insert(key, value);
+    fn set(&mut self, key: &[u8], value: &[u8]) -> Result<(), rocksdb::Error> {
+        self.cache.insert(key.to_vec(), value.to_vec());
         Ok(())
     }
 
-    fn del(&mut self, key: Vec<u8>) -> Result<(), rocksdb::Error> {
-        self.cache.remove(&key);
+    fn del(&mut self, key: &[u8]) -> Result<(), rocksdb::Error> {
+        self.cache.remove(key);
         Ok(())
     }
 }

--- a/src/state_db.rs
+++ b/src/state_db.rs
@@ -51,12 +51,12 @@ pub struct StateDB {
 }
 
 impl CommitData {
-    fn new(h: u32, prev_root: Vec<u8>, r: bool, expected: Vec<u8>, check_expected: bool) -> Self {
+    fn new(h: u32, prev_root: &[u8], r: bool, expected: &[u8], check_expected: bool) -> Self {
         Self {
             height: h,
-            prev_root,
+            prev_root: prev_root.to_vec(),
             readonly: r,
-            expected,
+            expected: expected.to_vec(),
             check_expected,
         }
     }
@@ -140,7 +140,7 @@ impl StateDB {
 
     fn get_by_key(&self, key: Vec<u8>, cb: Root<JsFunction>) -> Result<(), DataStoreError> {
         self.send(move |conn, channel| {
-            let result = conn.get([consts::PREFIX_STATE, key.as_slice()].concat());
+            let result = conn.get([consts::PREFIX_STATE, &key].concat());
 
             channel.send(move |mut ctx| {
                 let callback = cb.into_inner(&mut ctx);
@@ -162,9 +162,10 @@ impl StateDB {
         .map_err(|err| DataStoreError::Unknown(err.to_string()))
     }
 
-    fn exists(&self, key: Vec<u8>, cb: Root<JsFunction>) -> Result<(), DataStoreError> {
+    fn exists(&self, key: &[u8], cb: Root<JsFunction>) -> Result<(), DataStoreError> {
+        let key = key.to_vec();
         self.send(move |conn, channel| {
-            let key_with_prefix = [consts::PREFIX_STATE, key.as_slice()].concat();
+            let key_with_prefix = [consts::PREFIX_STATE, &key].concat();
             let exist = conn.key_may_exist(&key_with_prefix);
             let result = if exist {
                 conn.get(&key_with_prefix).map(|res| res.is_some())
@@ -194,7 +195,7 @@ impl StateDB {
     fn get_revert_result(
         conn: &rocksdb::DB,
         height: u32,
-        state_root: Vec<u8>,
+        state_root: &[u8],
         key_length: usize,
     ) -> Result<Vec<u8>, DataStoreError> {
         let diff_bytes = conn
@@ -206,7 +207,7 @@ impl StateDB {
             .map_err(|err| DataStoreError::Unknown(err.to_string()))?;
         let mut data = smt::UpdateData::new_with_hash(d.revert_update());
         let mut smtdb = smt_db::SmtDB::new(conn);
-        let mut tree = smt::SparseMerkleTree::new(&state_root, key_length, consts::SUBTREE_SIZE);
+        let mut tree = smt::SparseMerkleTree::new(state_root, key_length, consts::SUBTREE_SIZE);
         let prev_root = tree
             .commit(&mut smtdb, &mut data)
             .map_err(|err| DataStoreError::Unknown(err.to_string()))?;
@@ -236,7 +237,7 @@ impl StateDB {
     ) -> Result<(), mpsc::SendError<options::DbMessage>> {
         let key_length = self.key_length;
         self.send(move |conn, channel| {
-            let result = StateDB::get_revert_result(conn, height, state_root, key_length);
+            let result = StateDB::get_revert_result(conn, height, &state_root, key_length);
             channel.send(move |mut ctx| {
                 let callback = cb.into_inner(&mut ctx);
                 let this = ctx.undefined();
@@ -329,11 +330,10 @@ impl StateDB {
     fn prove(
         &self,
         root: Vec<u8>,
-        queries: &[Vec<u8>],
+        queries: Vec<Vec<u8>>,
         cb: Root<JsFunction>,
     ) -> Result<(), DataStoreError> {
         let key_length = self.key_length;
-        let queries = queries.to_vec();
         self.send(move |conn, channel| {
             let mut tree = smt::SparseMerkleTree::new(&root, key_length, consts::SUBTREE_SIZE);
             let mut smtdb = smt_db::SmtDB::new(conn);
@@ -514,7 +514,7 @@ impl StateDB {
         let db = ctx.this().downcast_or_throw::<SharedStateDB, _>(&mut ctx)?;
 
         let db = db.borrow_mut();
-        db.exists(key, cb)
+        db.exists(&key, cb)
             .or_else(|err| ctx.throw_error(err.to_string()))?;
 
         Ok(ctx.undefined())
@@ -609,7 +609,7 @@ impl StateDB {
             return ctx.throw_error(String::from("Readonly DB cannot be committed."));
         }
         let writer = writer.borrow().clone();
-        let commit_data = CommitData::new(height, prev_root, readonly, expected, check_root);
+        let commit_data = CommitData::new(height, &prev_root, readonly, &expected, check_root);
         db.commit(writer, commit_data, cb)
             .or_else(|err| ctx.throw_error(err.to_string()))?;
 
@@ -635,7 +635,7 @@ impl StateDB {
 
         let cb = ctx.argument::<JsFunction>(2)?.root(&mut ctx);
 
-        db.prove(state_root, &queries, cb)
+        db.prove(state_root, queries, cb)
             .or_else(|err| ctx.throw_error(err.to_string()))?;
 
         Ok(ctx.undefined())

--- a/src/state_db.rs
+++ b/src/state_db.rs
@@ -202,7 +202,7 @@ impl StateDB {
             .map_err(|err| DataStoreError::Unknown(err.to_string()))?
             .ok_or(DataStoreError::DiffNotFound(height))?;
 
-        let d = diff::Diff::decode(diff_bytes)
+        let d = diff::Diff::decode(&diff_bytes)
             .map_err(|err| DataStoreError::Unknown(err.to_string()))?;
         let mut data = smt::UpdateData::new_with_hash(d.revert_update());
         let mut smtdb = smt_db::SmtDB::new(conn);

--- a/src/state_db.rs
+++ b/src/state_db.rs
@@ -206,7 +206,7 @@ impl StateDB {
             .map_err(|err| DataStoreError::Unknown(err.to_string()))?;
         let mut data = smt::UpdateData::new_with_hash(d.revert_update());
         let mut smtdb = smt_db::SmtDB::new(conn);
-        let mut tree = smt::SparseMerkleTree::new(state_root, key_length, consts::SUBTREE_SIZE);
+        let mut tree = smt::SparseMerkleTree::new(&state_root, key_length, consts::SUBTREE_SIZE);
         let prev_root = tree
             .commit(&mut smtdb, &mut data)
             .map_err(|err| DataStoreError::Unknown(err.to_string()))?;
@@ -302,7 +302,7 @@ impl StateDB {
             let mut data = smt::UpdateData::new_with_hash(w.get_updated());
             let mut smtdb = smt_db::SmtDB::new(conn);
             let mut tree =
-                smt::SparseMerkleTree::new(d.prev_root, key_length, consts::SUBTREE_SIZE);
+                smt::SparseMerkleTree::new(&d.prev_root, key_length, consts::SUBTREE_SIZE);
             let root = tree.commit(&mut smtdb, &mut data);
             let result_info =
                 CommitResultInfo::new(root, &d.expected, d.height, d.readonly, d.check_expected);
@@ -335,7 +335,7 @@ impl StateDB {
         let key_length = self.key_length;
         let queries = queries.to_vec();
         self.send(move |conn, channel| {
-            let mut tree = smt::SparseMerkleTree::new(root, key_length, consts::SUBTREE_SIZE);
+            let mut tree = smt::SparseMerkleTree::new(&root, key_length, consts::SUBTREE_SIZE);
             let mut smtdb = smt_db::SmtDB::new(conn);
             let result = tree.prove(&mut smtdb, &queries);
 

--- a/src/state_writer.rs
+++ b/src/state_writer.rs
@@ -41,20 +41,19 @@ pub struct StateWriter {
 }
 
 impl StateCache {
-    fn new(val: Vec<u8>) -> Self {
+    fn new(val: &[u8]) -> Self {
         Self {
             init: None,
-            value: val,
+            value: val.to_vec(),
             dirty: false,
             deleted: false,
         }
     }
 
-    fn new_existing(val: Vec<u8>) -> Self {
-        let init = val.clone();
+    fn new_existing(val: &[u8]) -> Self {
         Self {
-            init: Some(init),
-            value: val,
+            init: Some(val.to_vec()),
+            value: val.to_vec(),
             dirty: false,
             deleted: false,
         }
@@ -81,12 +80,12 @@ impl StateWriter {
     }
 
     pub fn cache_new(&mut self, key: &[u8], value: &[u8]) {
-        let cache = StateCache::new(value.to_vec());
+        let cache = StateCache::new(value);
         self.cache.insert(key.to_vec(), cache);
     }
 
     pub fn cache_existing(&mut self, key: &[u8], value: &[u8]) {
-        let cache = StateCache::new_existing(value.to_vec());
+        let cache = StateCache::new_existing(value);
         self.cache.insert(key.to_vec(), cache);
     }
 

--- a/src/state_writer.rs
+++ b/src/state_writer.rs
@@ -184,15 +184,12 @@ impl StateWriter {
                 continue;
             }
             if value.deleted {
-                deleted.push(diff::KeyValue::new(key.to_vec(), value.value.clone()));
+                deleted.push(diff::KeyValue::new(key, &value.value));
                 batch.delete(key);
                 continue;
             }
             if value.dirty {
-                updated.push(diff::KeyValue::new(
-                    key.to_vec(),
-                    value.init.clone().unwrap().to_vec(),
-                ));
+                updated.push(diff::KeyValue::new(key, &value.init.clone().unwrap()));
                 batch.put(key, &value.value);
                 continue;
             }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -176,7 +176,7 @@ pub fn strip_left_false(a: &[bool]) -> Vec<bool> {
     result
 }
 
-pub fn bytes_in(list: &Vec<Vec<u8>>, a: &[u8]) -> bool {
+pub fn bytes_in(list: &[Vec<u8>], a: &[u8]) -> bool {
     for v in list {
         if is_bytes_equal(v, a) {
             return true;


### PR DESCRIPTION
### What was the problem?

This PR resolves #36

### How was it solved?

Convert `Vec<u8>` -> `&[u8]` as arguments, if it is better option.

### How was it tested?

All tests passed.