### PR TITLE
Reduce the number of .clone() function calls - Closes #37

### DIFF
--- a/src/batch.rs
+++ b/src/batch.rs
@@ -66,7 +66,7 @@ impl WriteBatch {
             .this()
             .downcast_or_throw::<JsBox<SendableWriteBatch>, _>(&mut ctx)?;
 
-        let batch = batch.borrow().clone();
+        let batch = batch.borrow();
         let mut inner_batch = batch.lock().unwrap();
 
         inner_batch.batch.put(key, value);
@@ -81,7 +81,7 @@ impl WriteBatch {
             .this()
             .downcast_or_throw::<JsBox<SendableWriteBatch>, _>(&mut ctx)?;
 
-        let batch = batch.borrow().clone();
+        let batch = batch.borrow();
         let mut inner_batch = batch.lock().unwrap();
 
         inner_batch.batch.delete(key);

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -156,8 +156,8 @@ impl Writer {
         }
     }
 
-    pub fn result(&self) -> Vec<u8> {
-        self.result.clone()
+    pub fn result(&self) -> &Vec<u8> {
+        &self.result
     }
 
     fn write_key(&mut self, wire_type: u32, field_number: u32) {

--- a/src/db.rs
+++ b/src/db.rs
@@ -275,7 +275,7 @@ impl Database {
             .this()
             .downcast_or_throw::<JsBox<Database>, _>(&mut ctx)?;
 
-        let batch = batch.borrow().clone();
+        let batch = Arc::clone(&batch.borrow());
 
         db.send(move |conn, channel| {
             let b = rocksdb::WriteBatch::default();
@@ -319,7 +319,7 @@ impl Database {
                 if utils::is_key_out_of_range(&options, &key, counter as i64, false) {
                     break;
                 }
-                let c = a_cb_on_data.clone();
+                let c = Arc::clone(&a_cb_on_data);
                 channel.send(move |mut ctx| {
                     let obj = ctx.empty_object();
                     let key_res = JsBuffer::external(&mut ctx, key);

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -21,7 +21,7 @@ impl KVPairCodec for KVPair {
         let mut writer = codec::Writer::new();
         writer.write_bytes(1, self.key());
         writer.write_bytes(2, self.value());
-        writer.result()
+        writer.result().to_vec()
     }
 }
 
@@ -64,7 +64,7 @@ impl Diff {
         let deleted: NestedVec = self.deleted.iter().map(|v| v.encode()).collect();
         writer.write_bytes_slice(3, &deleted);
 
-        writer.result()
+        writer.result().to_vec()
     }
 
     pub fn revert_update(&self) -> Cache {

--- a/src/in_memory_db.rs
+++ b/src/in_memory_db.rs
@@ -2,7 +2,6 @@ use neon::prelude::*;
 use neon::types::buffer::TypedArray;
 use std::cell::{RefCell, RefMut};
 use std::cmp;
-use std::collections::HashMap;
 
 use crate::batch;
 use crate::options::IterationOption;
@@ -28,7 +27,7 @@ fn sort_kv_pair(pairs: &mut [KVPair], reverse: bool) {
     pairs.sort_by(|a, b| b.key().cmp(a.key()));
 }
 
-fn get_key_value_pairs(db: RefMut<Database>, options: IterationOption) -> Vec<KVPair> {
+fn get_key_value_pairs(db: RefMut<Database>, options: &IterationOption) -> Vec<KVPair> {
     let no_range = options.gte.is_none() && options.lte.is_none();
     let cached = if no_range {
         db.cache_all()
@@ -42,9 +41,7 @@ fn get_key_value_pairs(db: RefMut<Database>, options: IterationOption) -> Vec<KV
     };
 
     let mut results = vec![];
-    let mut exist_map = HashMap::new();
     for kv in cached {
-        exist_map.insert(kv.key_as_vec(), true);
         results.push(kv);
     }
 
@@ -184,7 +181,7 @@ impl Database {
         let db = ctx.this().downcast_or_throw::<SharedStateDB, _>(&mut ctx)?;
         let db = db.borrow_mut();
 
-        let kv_pairs = get_key_value_pairs(db, options);
+        let kv_pairs = get_key_value_pairs(db, &options);
 
         let this = ctx.undefined();
         let arr = JsArray::new(&mut ctx, kv_pairs.len() as u32);

--- a/src/in_memory_smt.rs
+++ b/src/in_memory_smt.rs
@@ -29,7 +29,7 @@ impl JsFunctionContext<'_> {
             .context
             .this()
             .downcast_or_throw::<SharedInMemorySMT, _>(&mut self.context)?;
-        let in_memory_smt = in_memory_smt.borrow().clone();
+        let in_memory_smt = Arc::clone(&in_memory_smt.borrow());
 
         let state_root = self
             .context
@@ -84,7 +84,7 @@ impl JsFunctionContext<'_> {
                 let this = ctx.undefined();
                 let args: Vec<Handle<JsValue>> = match result {
                     Ok(val) => {
-                        let buffer = JsBuffer::external(&mut ctx, val.lock().unwrap().clone());
+                        let buffer = JsBuffer::external(&mut ctx, (**val.lock().unwrap()).clone());
                         vec![ctx.null().upcast(), buffer.upcast()]
                     },
                     Err(err) => vec![ctx.error(err.to_string())?.upcast()],
@@ -196,8 +196,8 @@ impl JsFunctionContext<'_> {
                 .as_slice(&self.context)
                 .to_vec();
             queries.push(QueryProof {
-                pair: KVPair::new(&key, &value),
-                bitmap,
+                pair: Arc::new(KVPair::new(&key, &value)),
+                bitmap: Arc::new(bitmap),
             });
         }
         let proof = Proof {

--- a/src/in_memory_smt.rs
+++ b/src/in_memory_smt.rs
@@ -84,7 +84,7 @@ impl JsFunctionContext<'_> {
                 let this = ctx.undefined();
                 let args: Vec<Handle<JsValue>> = match result {
                     Ok(val) => {
-                        let buffer = JsBuffer::external(&mut ctx, val.to_vec());
+                        let buffer = JsBuffer::external(&mut ctx, val.lock().unwrap().clone());
                         vec![ctx.null().upcast(), buffer.upcast()]
                     },
                     Err(err) => vec![ctx.error(err.to_string())?.upcast()],

--- a/src/state_writer.rs
+++ b/src/state_writer.rs
@@ -187,7 +187,7 @@ impl StateWriter {
                 continue;
             }
             if value.dirty {
-                updated.push(KVPair::new(key, &value.init.clone().unwrap()));
+                updated.push(KVPair::new(key, value.init.as_ref().unwrap()));
                 batch.put(&kv);
                 continue;
             }
@@ -210,7 +210,7 @@ impl StateWriter {
             .this()
             .downcast_or_throw::<JsBox<SendableStateWriter>, _>(&mut ctx)?;
 
-        let writer = batch.borrow().clone();
+        let writer = Arc::clone(&batch.borrow());
         let inner_writer = writer.lock().unwrap();
 
         let (value, deleted, exists) = inner_writer.get(&key);
@@ -234,7 +234,7 @@ impl StateWriter {
             .this()
             .downcast_or_throw::<JsBox<SendableStateWriter>, _>(&mut ctx)?;
 
-        let writer = batch.borrow().clone();
+        let writer = Arc::clone(&batch.borrow());
         let mut inner_writer = writer.lock().unwrap();
 
         inner_writer
@@ -252,7 +252,7 @@ impl StateWriter {
             .this()
             .downcast_or_throw::<JsBox<SendableStateWriter>, _>(&mut ctx)?;
 
-        let writer = batch.borrow().clone();
+        let writer = Arc::clone(&batch.borrow());
         let mut inner_writer = writer.lock().unwrap();
 
         inner_writer.cache_new(&SharedKVPair::new(&key, &value));
@@ -269,7 +269,7 @@ impl StateWriter {
             .this()
             .downcast_or_throw::<JsBox<SendableStateWriter>, _>(&mut ctx)?;
 
-        let writer = batch.borrow().clone();
+        let writer = Arc::clone(&batch.borrow());
         let mut inner_writer = writer.lock().unwrap();
 
         inner_writer.cache_existing(&pair);
@@ -284,7 +284,7 @@ impl StateWriter {
             .this()
             .downcast_or_throw::<JsBox<SendableStateWriter>, _>(&mut ctx)?;
 
-        let batch = writer.borrow().clone();
+        let batch = Arc::clone(&writer.borrow());
         let mut inner_writer = batch.lock().unwrap();
 
         inner_writer.delete(&key);
@@ -299,7 +299,7 @@ impl StateWriter {
             .this()
             .downcast_or_throw::<JsBox<SendableStateWriter>, _>(&mut ctx)?;
 
-        let writer = batch.borrow().clone();
+        let writer = Arc::clone(&batch.borrow());
         let inner_writer = writer.lock().unwrap();
 
         let cached = inner_writer.is_cached(&key);
@@ -312,7 +312,7 @@ impl StateWriter {
             .this()
             .downcast_or_throw::<JsBox<SendableStateWriter>, _>(&mut ctx)?;
 
-        let batch = writer.borrow().clone();
+        let batch = Arc::clone(&writer.borrow());
         let mut inner_writer = batch.lock().unwrap();
 
         let index = inner_writer.snapshot();
@@ -325,7 +325,7 @@ impl StateWriter {
             .this()
             .downcast_or_throw::<JsBox<SendableStateWriter>, _>(&mut ctx)?;
 
-        let batch = writer.borrow().clone();
+        let batch = Arc::clone(&writer.borrow());
         let mut inner_writer = batch.lock().unwrap();
         let index = ctx.argument::<JsNumber>(0)?.value(&mut ctx) as u32;
 
@@ -343,7 +343,7 @@ impl StateWriter {
             .this()
             .downcast_or_throw::<JsBox<SendableStateWriter>, _>(&mut ctx)?;
 
-        let writer = batch.borrow().clone();
+        let writer = Arc::clone(&batch.borrow());
         let inner_writer = writer.lock().unwrap();
 
         let results = inner_writer.get_range(&start, &end);

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 use std::ops::Add;
+use std::sync::{Arc, Mutex};
 
 use crate::codec;
 
@@ -7,6 +8,7 @@ pub type NestedVec = Vec<Vec<u8>>;
 pub type SharedNestedVec<'a> = Vec<&'a [u8]>;
 pub type Cache = HashMap<Vec<u8>, Vec<u8>>;
 pub type VecOption = Option<Vec<u8>>;
+pub type SharedVec = Arc<Mutex<Arc<Vec<u8>>>>;
 
 // Strong type of SMT with max value KEY_LENGTH * 8
 #[derive(Clone, Debug, Copy, PartialEq, Eq)]
@@ -211,19 +213,23 @@ impl KVPair {
 }
 
 impl<'a> SharedKVPair<'a> {
+    #[inline]
     pub fn new(key: &'a [u8], value: &'a [u8]) -> Self {
         Self(key, value)
     }
 
     #[allow(dead_code)]
+    #[inline]
     pub fn key(&self) -> &[u8] {
         self.0
     }
 
+    #[inline]
     pub fn value(&self) -> &[u8] {
         self.1
     }
 
+    #[inline]
     pub fn key_as_vec(&self) -> Vec<u8> {
         self.0.to_vec()
     }

--- a/src/types.rs
+++ b/src/types.rs
@@ -4,6 +4,7 @@ use std::ops::Add;
 use crate::codec;
 
 pub type NestedVec = Vec<Vec<u8>>;
+pub type SharedNestedVec<'a> = Vec<&'a [u8]>;
 pub type Cache = HashMap<Vec<u8>, Vec<u8>>;
 pub type VecOption = Option<Vec<u8>>;
 
@@ -38,6 +39,9 @@ pub struct DatabaseOptions {
 
 #[derive(Clone, Debug)]
 pub struct KVPair(pub Vec<u8>, pub Vec<u8>);
+
+#[derive(Clone, Debug)]
+pub struct SharedKVPair<'a>(pub &'a [u8], pub &'a [u8]);
 
 pub trait DB {
     fn get(&self, key: &[u8]) -> Result<VecOption, rocksdb::Error>;
@@ -203,6 +207,25 @@ impl KVPair {
     #[inline]
     pub fn is_empty_value(&self) -> bool {
         self.1.is_empty()
+    }
+}
+
+impl<'a> SharedKVPair<'a> {
+    pub fn new(key: &'a [u8], value: &'a [u8]) -> Self {
+        Self(key, value)
+    }
+
+    #[allow(dead_code)]
+    pub fn key(&self) -> &[u8] {
+        self.0
+    }
+
+    pub fn value(&self) -> &[u8] {
+        self.1
+    }
+
+    pub fn key_as_vec(&self) -> Vec<u8> {
+        self.0.to_vec()
     }
 }
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -19,7 +19,7 @@ pub fn get_iteration_mode<'a>(
         let lte = options
             .lte
             .clone()
-            .unwrap_or_else(|| vec![255; options.gte.clone().unwrap().len()]);
+            .unwrap_or_else(|| vec![255; options.gte.as_ref().unwrap().len()]);
         *opt = if has_prefix {
             [consts::PREFIX_STATE, lte.as_slice()].concat()
         } else {
@@ -30,7 +30,7 @@ pub fn get_iteration_mode<'a>(
         let gte = options
             .gte
             .clone()
-            .unwrap_or_else(|| vec![0; options.lte.clone().unwrap().len()]);
+            .unwrap_or_else(|| vec![0; options.lte.as_ref().unwrap().len()]);
         *opt = if has_prefix {
             [consts::PREFIX_STATE, gte.as_slice()].concat()
         } else {


### PR DESCRIPTION
### What was the problem?

This PR resolves #37

### How was it solved?

Code was refactored to use `reference`, `Arc`, `Mutex` and their combinations to replace `.clone()` function calls.
Some `.clone()` function calls are still in the code because they really need to be there or it won't benefit if they were removed or the code will become messed up if `.clone()` functions would be removed and replaced with any of the techniques used to remove such function calls.

### How was it tested?

All tests passed.