### PR TITLE
Add RocksDB create checkpoint interface - Closes #54

### DIFF
--- a/database.js
+++ b/database.js
@@ -23,6 +23,7 @@ const {
     db_del,
     db_write,
     db_iterate,
+    db_checkpoint,
     batch_new,
     batch_set,
     batch_del,
@@ -186,6 +187,17 @@ class Database {
 
     close() {
         db_close.call(this._db);
+    }
+
+    async checkpoint(path) {
+        return new Promise((resolve, reject) => {
+            db_checkpoint.call(this._db, path, err => {
+                if (err) {
+                    return reject(err);
+                }
+                resolve();
+            });
+        });
     }
 }
 

--- a/src/db.rs
+++ b/src/db.rs
@@ -225,4 +225,18 @@ impl Database {
 
         Ok(ctx.undefined())
     }
+
+    pub fn js_checkpoint(mut ctx: FunctionContext) -> JsResult<JsUndefined> {
+        let path = ctx.argument::<JsString>(0)?.value(&mut ctx);
+        let cb = ctx.argument::<JsFunction>(1)?.root(&mut ctx);
+
+        let db = ctx
+            .this()
+            .downcast_or_throw::<JsBox<Database>, _>(&mut ctx)?;
+
+        db.checkpoint(path, cb)
+            .or_else(|err| ctx.throw_error(err.to_string()))?;
+
+        Ok(ctx.undefined())
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,6 +32,7 @@ fn main(mut cx: ModuleContext) -> NeonResult<()> {
     cx.export_function("db_del", db::Database::js_del)?;
     cx.export_function("db_write", db::Database::js_write)?;
     cx.export_function("db_iterate", db::Database::js_iterate)?;
+    cx.export_function("db_checkpoint", db::Database::js_checkpoint)?;
 
     cx.export_function(
         "batch_new",
@@ -56,6 +57,7 @@ fn main(mut cx: ModuleContext) -> NeonResult<()> {
         "state_db_clean_diff_until",
         state_db::StateDB::js_clean_diff_until,
     )?;
+    cx.export_function("state_db_checkpoint", state_db::StateDB::js_checkpoint)?;
 
     cx.export_function(
         "state_writer_new",

--- a/src/state_db.rs
+++ b/src/state_db.rs
@@ -596,4 +596,18 @@ impl StateDB {
 
         Ok(ctx.undefined())
     }
+
+    pub fn js_checkpoint(mut ctx: FunctionContext) -> JsResult<JsUndefined> {
+        let db = ctx.this().downcast_or_throw::<SharedStateDB, _>(&mut ctx)?;
+        let db = db.borrow();
+
+        let path = ctx.argument::<JsString>(0)?.value(&mut ctx);
+        let cb = ctx.argument::<JsFunction>(1)?.root(&mut ctx);
+
+        db.common
+            .checkpoint(path, cb)
+            .or_else(|err| ctx.throw_error(err.to_string()))?;
+
+        Ok(ctx.undefined())
+    }
 }

--- a/state_db.js
+++ b/state_db.js
@@ -24,6 +24,7 @@ const {
     state_db_prove,
     state_db_verify,
     state_db_clean_diff_until,
+    state_db_checkpoint,
     state_writer_new,
     state_writer_get,
     state_writer_update,
@@ -58,9 +59,9 @@ class StateReader {
                 // If result is empty, force to use different memory space from what's given from binding
                 // Issue: https://github.com/nodejs/node/issues/32463
                 if (result.length === 0) {
-					resolve(Buffer.alloc(0));
-					return;
-				}
+                    resolve(Buffer.alloc(0));
+                    return;
+                }
                 resolve(result);
             });
         });
@@ -116,9 +117,9 @@ class StateReadWriter {
                 // If result is empty, force to use different memory space from what's given from binding
                 // Issue: https://github.com/nodejs/node/issues/32463
                 if (result.length === 0) {
-					resolve(Buffer.alloc(0));
-					return;
-				}
+                    resolve(Buffer.alloc(0));
+                    return;
+                }
                 resolve(result);
             });
         });
@@ -279,9 +280,9 @@ class StateDB {
                 // If result is empty, force to use different memory space from what's given from binding
                 // Issue: https://github.com/nodejs/node/issues/32463
                 if (result.length === 0) {
-					resolve(Buffer.alloc(0));
-					return;
-				}
+                    resolve(Buffer.alloc(0));
+                    return;
+                }
                 resolve(result);
             });
         });
@@ -376,6 +377,17 @@ class StateDB {
 
     close() {
         state_db_close.call(this._db);
+    }
+
+    async checkpoint(path) {
+        return new Promise((resolve, reject) => {
+            state_db_checkpoint.call(this._db, path, err => {
+                if (err) {
+                    return reject(err);
+                }
+                resolve();
+            });
+        });
     }
 }
 

--- a/types.d.ts
+++ b/types.d.ts
@@ -49,6 +49,7 @@ export class Database {
     clear(options?: IterateOptions): Promise<void>;
     close(): void;
     newReader(): DatabaseReader;
+    checkpoint(path: string): Promise<void>;
 }
 
 export class InMemoryDatabase {
@@ -116,6 +117,7 @@ export class StateDB {
     newReader(): StateReader;
     newReadWriter(): StateReadWriter;
     close(): void;
+    checkpoint(path: string): Promise<void>;
 }
 
 export class SparseMerkleTree {


### PR DESCRIPTION
### What was the problem?

This PR resolves #54 

### How was it solved?

Function for creating RocksDB checkpoint for `Database` and `StateDB` is exposed to JS library and it is possible to call it from JS code.

### How was it tested?

- some new tests were implemented
- all tests passed