### PR TITLE
Fix a variable name and its usage - Closes #66

### DIFF
--- a/src/in_memory_db.rs
+++ b/src/in_memory_db.rs
@@ -5,12 +5,9 @@ use std::cmp;
 use std::sync::Arc;
 
 use crate::batch;
-use crate::common_db::{
-    JsBoxRef, JsNewWithBoxRef, Kind as DBKind, NewDBWithContext, Options as DBOptions,
-    OptionsWithContext,
-};
+use crate::common_db::JsBoxRef;
 use crate::options::IterationOption;
-use crate::types::{Cache, KVPair, New};
+use crate::types::{Cache, KVPair};
 use crate::utils;
 
 type SharedStateDB = JsBoxRef<Database>;
@@ -69,40 +66,6 @@ impl rocksdb::WriteBatchIterator for CacheData {
     }
 }
 
-impl NewDBWithContext for Database {
-    fn new_db_with_context<'a, C>(
-        _: &mut C,
-        _: String,
-        _: DBOptions,
-        _: DBKind,
-    ) -> Result<Self, rocksdb::Error>
-    where
-        C: Context<'a>,
-        Self: Sized,
-    {
-        Ok(Database {
-            cache: CacheData { data: Cache::new() },
-        })
-    }
-}
-
-impl JsNewWithBoxRef for Database {
-    fn js_new_with_box_ref<T: OptionsWithContext, U: NewDBWithContext + Send + Finalize>(
-        mut ctx: FunctionContext,
-    ) -> JsResult<JsBoxRef<U>> {
-        let db = U::new_db_with_context(
-            &mut ctx,
-            String::from(""),
-            DBOptions::new(),
-            DBKind::InMemoryDB,
-        )
-        .or_else(|err| ctx.throw_error(&err))?;
-        let ref_db = RefCell::new(db);
-
-        return Ok(ctx.boxed(ref_db));
-    }
-}
-
 impl Finalize for Database {}
 impl Database {
     fn cache_range(&self, start: &[u8], end: &[u8]) -> Vec<KVPair> {
@@ -146,6 +109,15 @@ impl Database {
 }
 
 impl Database {
+    pub fn js_new(mut ctx: FunctionContext) -> JsResult<JsBoxRef<Database>> {
+        let db = Database {
+            cache: CacheData { data: Cache::new() },
+        };
+        let ref_db = RefCell::new(db);
+
+        Ok(ctx.boxed(ref_db))
+    }
+
     pub fn js_get(mut ctx: FunctionContext) -> JsResult<JsUndefined> {
         let key = ctx.argument::<JsTypedArray<u8>>(0)?.as_slice(&ctx).to_vec();
         let cb = ctx.argument::<JsFunction>(1)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 use neon::prelude::*;
 
 use crate::common_db::{JsNewWithArcMutex, JsNewWithBox, JsNewWithBoxRef};
-pub use crate::types::{Cache, KeyLength, NestedVec, SharedKVPair};
+pub use crate::types::{Cache, DbOptions, KeyLength, NestedVec, SharedKVPair};
 
 pub mod batch;
 mod codec;
@@ -25,7 +25,7 @@ extern crate tempdir;
 fn main(mut cx: ModuleContext) -> NeonResult<()> {
     cx.export_function(
         "db_new",
-        db::Database::js_new_with_box::<common_db::Options, db::Database>,
+        db::Database::js_new_with_box::<DbOptions, db::Database>,
     )?;
     cx.export_function("db_clear", db::Database::js_clear)?;
     cx.export_function("db_close", db::Database::js_close)?;
@@ -46,7 +46,7 @@ fn main(mut cx: ModuleContext) -> NeonResult<()> {
 
     cx.export_function(
         "state_db_new",
-        state_db::StateDB::js_new_with_box_ref::<common_db::Options, state_db::StateDB>,
+        state_db::StateDB::js_new_with_box_ref::<DbOptions, state_db::StateDB>,
     )?;
     cx.export_function(
         "state_db_get_current_state",
@@ -92,10 +92,7 @@ fn main(mut cx: ModuleContext) -> NeonResult<()> {
         state_writer::StateWriter::js_restore_snapshot,
     )?;
 
-    cx.export_function(
-        "in_memory_db_new",
-        in_memory_db::Database::js_new_with_box_ref::<common_db::Options, in_memory_db::Database>,
-    )?;
+    cx.export_function("in_memory_db_new", in_memory_db::Database::js_new)?;
     cx.export_function("in_memory_db_clone", in_memory_db::Database::js_clone)?;
     cx.export_function("in_memory_db_get", in_memory_db::Database::js_get)?;
     cx.export_function("in_memory_db_set", in_memory_db::Database::js_set)?;

--- a/src/options.rs
+++ b/src/options.rs
@@ -1,9 +1,9 @@
 use neon::prelude::*;
 use neon::types::buffer::TypedArray;
 
-use crate::common_db::{Options as DBOptions, OptionsWithContext};
+use crate::common_db::OptionsWithContext;
 use crate::consts;
-use crate::types::{KeyLength, VecOption};
+use crate::types::{DbOptions, KeyLength, VecOption};
 
 pub type DbCallback = Box<dyn FnOnce(&mut rocksdb::DB, &Channel) + Send>;
 
@@ -23,7 +23,7 @@ pub struct IterationOption {
     pub lte: VecOption,
 }
 
-impl OptionsWithContext for DBOptions {
+impl OptionsWithContext for DbOptions {
     fn new_with_context<'a, C>(
         ctx: &mut C,
         input: Option<Handle<JsValue>>,
@@ -32,7 +32,7 @@ impl OptionsWithContext for DBOptions {
         C: Context<'a>,
     {
         if input.is_none() {
-            return Ok(Self::new());
+            return Ok(Self::default());
         }
         let obj = input.unwrap().downcast_or_throw::<JsObject, _>(ctx)?;
         let readonly = obj
@@ -53,19 +53,13 @@ impl OptionsWithContext for DBOptions {
                 .unwrap_or_else(|| consts::KEY_LENGTH.into()),
         );
 
-        Ok(Self {
-            readonly,
-            key_length,
-        })
+        Ok(Self::new(readonly, key_length))
     }
 }
 
-impl DBOptions {
-    fn new() -> Self {
-        Self {
-            readonly: false,
-            key_length: consts::KEY_LENGTH,
-        }
+impl Default for DbOptions {
+    fn default() -> Self {
+        Self::new(false, consts::KEY_LENGTH)
     }
 }
 


### PR DESCRIPTION
### What was the problem?

This PR resolves #66 

### How was it solved?
 - Introduce a new base struct for `types::Options`
 - Introduce two new structs from `types::Options` for `DbOptions` and `CommitOptions`

### How was it tested?
 - All tests passed.