### PR TITLE
Fix memory binding issue in db.prove function - Closes #70

### DIFF
--- a/src/smt.rs
+++ b/src/smt.rs
@@ -1204,14 +1204,14 @@ impl SparseMerkleTree {
         query_key: &[u8],
         height: Height,
     ) -> Result<(SharedNode, Height), SMTError> {
-        let mut bin_offset = 0;
+        let mut bin_offset: usize = 0;
         let mut current_node: Option<SharedNode> = None;
-        let bin_idx = self.find_index(query_key, height)?;
+        let bin_idx: usize = self.find_index(query_key, height)?.into();
         let mut h = 0;
         for i in 0..current_subtree.nodes.len() {
             h = current_subtree.structure[i];
             current_node = Some(Arc::clone(&current_subtree.nodes[i]));
-            let new_offset = 1 << (self.subtree_height.sub_to_usize(h));
+            let new_offset: usize = 1 << (self.subtree_height.sub_to_usize(h));
             if bin_offset <= bin_idx && bin_idx < bin_offset + new_offset {
                 break;
             }

--- a/state_db.js
+++ b/state_db.js
@@ -150,10 +150,10 @@ class StateReadWriter {
         const defaultOptions = getOptionsWithDefault(options);
         const result = await new Promise((resolve, reject) => {
             state_db_range_with_writer.call(this._db, this.writer, defaultOptions, (err, result) => {
-            if (err) {
-                return reject(err);
-            }
-            resolve(result);
+                if (err) {
+                    return reject(err);
+                }
+                resolve(result);
             });
         });
         result.sort((a, b) => {
@@ -268,6 +268,13 @@ class StateDB {
             state_db_prove.call(this._db, root, queries, (err, result) => {
                 if (err) {
                     return reject(err);
+                }
+                // If result is empty, force to use different memory space from what's given from binding
+                // Issue: https://github.com/nodejs/node/issues/32463
+                for (const query of result.queries) {
+                    if (query.value.length === 0) {
+                        query.value = Buffer.alloc(0);
+                    }
                 }
                 resolve(result);
             });

--- a/test/statedb.spec.js
+++ b/test/statedb.spec.js
@@ -533,8 +533,7 @@ describe('statedb', () => {
         });
 
         describe('proof', () => {
-            // TODO: If any of these two unit tests are included, the test will sometimes fail. It seems there is a bug in db.prove function.
-            /*it('should generate non-inclusion proof and verify that a result is correct', async () => {
+            it('should generate non-inclusion proof and verify that a result is correct', async () => {
                 const queries = [getRandomBytes(38), getRandomBytes(38)];
                 const proof = await db.prove(root, queries);
 
@@ -553,7 +552,7 @@ describe('statedb', () => {
                 const result = await db.verify(root, queries, proof);
 
                 expect(result).toEqual(false);
-            });*/
+            });
 
             it('should generate inclusion proof and verify that a result is correct', async () => {
                 const queries = [


### PR DESCRIPTION
### What was the problem?

This PR resolves #70

### How was it solved?

- Fixed addition overflow issue in `find_current_node` function in `smt.rs`
- Forced to use different memory space from what's given from binding for `prove` function in `state_db.js`

### How was it tested?

- Two new JS unit tests were implemented
- All tests passed