### PR TITLE
Fix closing DB which leaves the database locked

### DIFF
--- a/src/database/reader_writer/reader_base.rs
+++ b/src/database/reader_writer/reader_base.rs
@@ -9,6 +9,7 @@ use neon::handle::{Handle, Root};
 use neon::result::JsResult;
 use neon::types::{Finalize, JsBuffer, JsFunction, JsValue};
 
+use crate::database::traits::Unwrap;
 use crate::database::types::{JsBoxRef, Kind, SnapshotMessage};
 use crate::state_db::SharedStateDB;
 
@@ -38,7 +39,7 @@ impl ReaderBase {
         let db = db.borrow();
         let conn = db.arc_clone();
         thread::spawn(move || {
-            let snapshot = conn.snapshot();
+            let snapshot = conn.unwrap().snapshot();
             while let Ok(message) = rx.recv() {
                 match message {
                     SnapshotMessage::Callback(f) => {

--- a/src/database/types.rs
+++ b/src/database/types.rs
@@ -1,4 +1,5 @@
 use std::cell::RefCell;
+use std::sync::Arc;
 
 use neon::event::Channel;
 use neon::types::JsBox;
@@ -12,6 +13,7 @@ pub type DbOptions = Options<KeyLength>;
 
 pub type JsBoxRef<T> = JsBox<RefCell<T>>;
 pub type JsArcMutex<T> = JsBoxRef<ArcMutex<T>>;
+pub type ArcOptionDB = Arc<Option<rocksdb::DB>>;
 
 /// Messages sent on the database channel
 pub enum Message<T> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,7 @@ use crate::database::db;
 use crate::database::in_memory::in_memory_db;
 use crate::database::reader_writer::read_writer_db;
 use crate::database::reader_writer::reader_db;
-use crate::database::traits::{JsNewWithArcMutex, JsNewWithBox, JsNewWithBoxRef};
+use crate::database::traits::{JsNewWithArcMutex, JsNewWithBoxRef};
 use crate::database::types::DbOptions;
 use crate::sparse_merkle_tree::in_memory_smt;
 use crate::state::state_db;
@@ -32,7 +32,10 @@ use state_writer::StateWriter;
 
 #[neon::main]
 fn main(mut cx: ModuleContext) -> NeonResult<()> {
-    cx.export_function("db_new", Database::js_new_with_box::<DbOptions, Database>)?;
+    cx.export_function(
+        "db_new",
+        Database::js_new_with_box_ref::<DbOptions, Database>,
+    )?;
     cx.export_function("db_clear", Database::js_clear)?;
     cx.export_function("db_close", Database::js_close)?;
     cx.export_function("db_get", Database::js_get)?;

--- a/test/database.spec.js
+++ b/test/database.spec.js
@@ -32,6 +32,19 @@ describe('database', () => {
             db.close();
         });
 
+        it('should be able to open after closing', async () => {
+            const newDBPath = path.join(os.tmpdir(), 'db', Date.now().toString());
+            fs.mkdirSync(newDBPath, { recursive: true });
+            const newDB = new Database(newDBPath);
+            const key = getRandomBytes();
+            const value = getRandomBytes();
+            await newDB.set(key, value);
+            newDB.close();
+
+            const reopenDB = new Database(newDBPath);
+            await expect(reopenDB.get(key)).resolves.toEqual(value);
+        });
+
         it('should open DB', () => {
             expect(db).not.toBeUndefined();
         });


### PR DESCRIPTION
### What was the problem?

This PR resolves #78

### How was it solved?

- Refactor the `DB` to stores an `option` of DB and change it to `None` in `close` function.

### How was it tested?

- Add a new unit test to check the new implementation.
- All tests passed.