### PR TITLE
Expose calculateRoot for the SparseMerkleTree and StateDB

### DIFF
--- a/sparse_merkle_tree.js
+++ b/sparse_merkle_tree.js
@@ -17,6 +17,7 @@ const {
     in_memory_smt_update,
     in_memory_smt_prove,
     in_memory_smt_verify,
+    in_memory_smt_calculate_root,
 } = require("./bin-package/index.node");
 
 const DEFAULT_KEY_LENGTH = 38;
@@ -69,6 +70,18 @@ class SparseMerkleTree {
     async verify(root, queries, proof) {
         return new Promise((resolve, reject) => {
             in_memory_smt_verify.call(null, root, queries, proof, this._keyLength, (err, result) => {
+                if (err) {
+                    reject(err);
+                    return;
+                }
+                resolve(result);
+            });
+        });
+    }
+
+    async calculateRoot(proof) {
+        return new Promise((resolve, reject) => {
+            in_memory_smt_calculate_root.call(null, proof, (err, result) => {
                 if (err) {
                     reject(err);
                     return;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,6 +74,7 @@ fn main(mut cx: ModuleContext) -> NeonResult<()> {
     cx.export_function("state_db_verify", StateDB::js_verify)?;
     cx.export_function("state_db_clean_diff_until", StateDB::js_clean_diff_until)?;
     cx.export_function("state_db_checkpoint", StateDB::js_checkpoint)?;
+    cx.export_function("state_db_calculate_root", StateDB::js_calculate_root)?;
 
     let state_writer_new = StateWriter::js_new_with_arc_mutex::<StateWriter>;
     let restore_snapshot = StateWriter::js_restore_snapshot;
@@ -95,6 +96,10 @@ fn main(mut cx: ModuleContext) -> NeonResult<()> {
     cx.export_function("in_memory_smt_update", InMemorySMT::js_update)?;
     cx.export_function("in_memory_smt_prove", InMemorySMT::js_prove)?;
     cx.export_function("in_memory_smt_verify", InMemorySMT::js_verify)?;
+    cx.export_function(
+        "in_memory_smt_calculate_root",
+        InMemorySMT::js_calculate_root,
+    )?;
 
     Ok(())
 }

--- a/src/sparse_merkle_tree/in_memory_smt.rs
+++ b/src/sparse_merkle_tree/in_memory_smt.rs
@@ -8,6 +8,7 @@ use neon::types::buffer::TypedArray;
 use crate::consts;
 use crate::database::traits::{DatabaseKind, JsNewWithArcMutex, NewDBWithKeyLength};
 use crate::database::types::{JsArcMutex, Kind as DBKind};
+use crate::sparse_merkle_tree::smt::QueryProofWithProof;
 use crate::sparse_merkle_tree::smt_db;
 use crate::sparse_merkle_tree::{Proof, QueryProof, SparseMerkleTree, UpdateData};
 use crate::types::{ArcMutex, Cache, KVPair, KeyLength, NestedVec};
@@ -184,8 +185,8 @@ impl JsFunctionContext<'_> {
         Ok(())
     }
 
-    fn get_proof(&mut self) -> NeonResult<Proof> {
-        let raw_proof = self.context.argument::<JsObject>(2)?;
+    fn get_proof(&mut self, pos: i32) -> NeonResult<Proof> {
+        let raw_proof = self.context.argument::<JsObject>(pos)?;
         let mut sibling_hashes = NestedVec::new();
         let raw_sibling_hashes = raw_proof
             .get::<JsArray, _, _>(&mut self.context, "siblingHashes")?
@@ -248,7 +249,7 @@ impl JsFunctionContext<'_> {
             parsed_query_keys.push(key);
         }
 
-        let proof = self.get_proof()?;
+        let proof = self.get_proof(2)?;
 
         let key_length = self
             .context
@@ -309,6 +310,41 @@ impl InMemorySMT {
                     },
                     Err(err) => vec![ctx.error(err.to_string())?.upcast()],
                 };
+                callback.call(&mut ctx, this, args)?;
+
+                Ok(())
+            })
+        });
+
+        Ok(js_context.context.undefined())
+    }
+
+    /// js_calculate_root is handler for JS ffi.
+    /// it calculate and returns the root hash of the in memory database.
+    pub fn js_calculate_root(ctx: FunctionContext) -> JsResult<JsUndefined> {
+        let mut js_context = JsFunctionContext { context: ctx };
+
+        let proof = js_context.get_proof(0)?;
+        let callback = js_context
+            .context
+            .argument::<JsFunction>(1)?
+            .root(&mut js_context.context);
+        let channel = js_context.context.channel();
+
+        thread::spawn(move || {
+            let filter_map = SparseMerkleTree::prepare_queries_with_proof_map(&proof);
+            let mut filtered_proof = filter_map
+                .values()
+                .cloned()
+                .collect::<Vec<QueryProofWithProof>>();
+            let result =
+                SparseMerkleTree::calculate_root(&proof.sibling_hashes, &mut filtered_proof);
+
+            channel.send(move |mut ctx| {
+                let callback = callback.into_inner(&mut ctx);
+                let this = ctx.undefined();
+                let buffer = JsBuffer::external(&mut ctx, result);
+                let args: Vec<Handle<JsValue>> = vec![ctx.null().upcast(), buffer.upcast()];
                 callback.call(&mut ctx, this, args)?;
 
                 Ok(())

--- a/src/sparse_merkle_tree/mod.rs
+++ b/src/sparse_merkle_tree/mod.rs
@@ -2,4 +2,4 @@ pub mod in_memory_smt;
 pub mod smt;
 pub mod smt_db;
 
-pub use smt::{Proof, QueryProof, SparseMerkleTree, UpdateData};
+pub use smt::{Proof, QueryProof, QueryProofWithProof, SparseMerkleTree, UpdateData};

--- a/src/state/state_db.rs
+++ b/src/state/state_db.rs
@@ -382,8 +382,8 @@ impl StateDB {
             .map_err(|err| DataStoreError::Unknown(err.to_string()))
     }
 
-    fn proof(ctx: &mut FunctionContext) -> NeonResult<smt::Proof> {
-        let raw_proof = ctx.argument::<JsObject>(2)?;
+    fn proof(ctx: &mut FunctionContext, pos: i32) -> NeonResult<smt::Proof> {
+        let raw_proof = ctx.argument::<JsObject>(pos)?;
         let raw_sibling_hashes = raw_proof
             .get::<JsArray, _, _>(ctx, "siblingHashes")?
             .to_vec(ctx)?;
@@ -720,7 +720,7 @@ impl StateDB {
         let key_length = db.options.key_length();
         let state_root = ctx.argument::<JsTypedArray<u8>>(0)?.as_slice(&ctx).to_vec();
 
-        let proof = Self::proof(&mut ctx)?;
+        let proof = Self::proof(&mut ctx, 2)?;
         let parsed_query_keys = Self::parse_query_keys(&mut ctx)?;
         let callback = ctx.argument::<JsFunction>(3)?.root(&mut ctx);
         let channel = ctx.channel();
@@ -781,6 +781,40 @@ impl StateDB {
         db.common
             .checkpoint(path, callback)
             .or_else(|err| ctx.throw_error(err.to_string()))?;
+
+        Ok(ctx.undefined())
+    }
+
+    /// js_calculate_root is handler for JS ffi.
+    /// js "this" - StateDB.
+    /// - @params(0) - proof { siblingHashes: &[&[u8]]; queries: { key: &[u8]; value: &[u8]; bitmap: &[u8]; }[]; }
+    /// - @params(1) - callback to return the result.
+    /// - @callback(0) - Error.
+    /// - @callback(1) - root: &[u8].
+    pub fn js_calculate_root(mut ctx: FunctionContext) -> JsResult<JsUndefined> {
+        let proof = Self::proof(&mut ctx, 0)?;
+        let callback = ctx.argument::<JsFunction>(1)?.root(&mut ctx);
+        let channel = ctx.channel();
+
+        thread::spawn(move || {
+            let filter_map = smt::SparseMerkleTree::prepare_queries_with_proof_map(&proof);
+            let mut filtered_proof = filter_map
+                .values()
+                .cloned()
+                .collect::<Vec<smt::QueryProofWithProof>>();
+            let result =
+                smt::SparseMerkleTree::calculate_root(&proof.sibling_hashes, &mut filtered_proof);
+
+            channel.send(move |mut ctx| {
+                let callback = callback.into_inner(&mut ctx);
+                let this = ctx.undefined();
+                let buffer = JsBuffer::external(&mut ctx, result);
+                let args: Vec<Handle<JsValue>> = vec![ctx.null().upcast(), buffer.upcast()];
+                callback.call(&mut ctx, this, args)?;
+
+                Ok(())
+            })
+        });
 
         Ok(ctx.undefined())
     }

--- a/state_db.js
+++ b/state_db.js
@@ -26,6 +26,7 @@ const {
     state_db_verify,
     state_db_clean_diff_until,
     state_db_checkpoint,
+    state_db_calculate_root,
     state_writer_new,
     state_writer_snapshot,
     state_writer_restore_snapshot,
@@ -330,6 +331,17 @@ class StateDB {
                     return reject(err);
                 }
                 resolve();
+            });
+        });
+    }
+
+    async calculateRoot(proof) {
+        return new Promise((resolve, reject) => {
+            state_db_calculate_root.call(this._db, proof, (err, result) => {
+                if (err) {
+                    return reject(err);
+                }
+                resolve(result);
             });
         });
     }

--- a/test/sparse_merkle_tree.spec.js
+++ b/test/sparse_merkle_tree.spec.js
@@ -251,4 +251,26 @@ describe('SparseMerkleTree', () => {
 			});
 		}
 	});
+
+	describe('calculateRoot', () => {
+		for (const test of ProofFixtures.testCases) {
+			// eslint-disable-next-line no-loop-func
+			it(test.description, async () => {
+				const smt = new SparseMerkleTree(32);
+				const outputMerkleRoot = test.output.merkleRoot;
+				const outputProof = test.output.proof;
+
+				const proof = {
+					siblingHashes: outputProof.siblingHashes.map(q => Buffer.from(q, 'hex')),
+					queries: outputProof.queries.map(q => ({
+						key: Buffer.from(q.key, 'hex'),
+						value: Buffer.from(q.value, 'hex'),
+						bitmap: Buffer.from(q.bitmap, 'hex'),
+					}))
+				};
+
+				await expect(smt.calculateRoot(proof)).resolves.toEqual(Buffer.from(outputMerkleRoot, 'hex'));
+			});
+		}
+	});
 });

--- a/test/statedb.spec.js
+++ b/test/statedb.spec.js
@@ -617,5 +617,15 @@ describe('statedb', () => {
                 expect(result).toEqual(false);
             });
         });
+
+        describe('calculateRoot', () => {
+            it('should calculate sparse merkle tree root', async () => {
+                const queries = [getRandomBytes(38), getRandomBytes(38)];
+                const proof = await db.prove(root, queries);
+
+                await expect(db.calculateRoot(proof)).resolves.toEqual(root);
+            });
+
+        });
     });
 });

--- a/types.d.ts
+++ b/types.d.ts
@@ -124,6 +124,7 @@ export class StateDB {
     close(): void;
     checkpoint(path: string): Promise<void>;
     getCurrentState(): Promise<CurrentState>;
+    calculateRoot(proof: Proof): Promise<Buffer>;
 }
 
 export class SparseMerkleTree {
@@ -131,4 +132,5 @@ export class SparseMerkleTree {
     update(root: Buffer, kvpair: { key: Buffer, value: Buffer }[]): Promise<Buffer>;
     prove(root: Buffer, queries: Buffer[]): Promise<Proof>;
     verify(root: Buffer, queries: Buffer[], proof: Proof): Promise<boolean>;
+    calculateRoot(proof: Proof): Promise<Buffer>;
 }


### PR DESCRIPTION
### What was the problem?

This PR resolves #80 

### How was it solved?

- `calculateRoot` was exposed that it can be used in JS side for `SparseMerkleTree` and `StateDB` modules.

### How was it tested?

- New unit tests were added.
- All previous unit tests passed.