### PR TITLE
Fix stateDB range

### DIFF
--- a/src/database/reader_writer/read_writer_db.rs
+++ b/src/database/reader_writer/read_writer_db.rs
@@ -176,9 +176,10 @@ impl ReadWriter {
                         } else if deleted {
                             continue;
                         } else {
-                            let shared_pair = SharedKVPair::new(pair.key(), pair.value());
+                            // key is stored and returned without prefix
+                            let shared_pair = SharedKVPair::new(key_without_prefix, pair.value());
                             writer.cache_existing(&shared_pair);
-                            result.insert(pair.key_as_vec(), pair.value_as_vec());
+                            result.insert(shared_pair.key_as_vec(), shared_pair.value_as_vec());
                         }
                     }
                     cache_to_js_array(&mut ctx, &result)?

--- a/src/types.rs
+++ b/src/types.rs
@@ -144,7 +144,7 @@ impl Sub for Height {
 impl From<KeyLength> for u16 {
     #[inline]
     fn from(value: KeyLength) -> u16 {
-        value.0 as u16
+        value.0
     }
 }
 

--- a/test/statedb.spec.js
+++ b/test/statedb.spec.js
@@ -381,8 +381,11 @@ describe('statedb', () => {
                 });
 
                 expect(result).toHaveLength(2);
-                expect(result[0].value).toEqual(newValue);
-                expect(result[1].value).toEqual(initState[2].value);
+                expect(result[0]).toEqual({
+                    key: initState[1].key,
+                    value: newValue,
+                });
+                expect(result[1]).toEqual(initState[2]);
             });
 
             it('should return updated value with range in reverse', async () => {


### PR DESCRIPTION
### What was the problem?

This PR resolves #83 

### How was it solved?
Update range iteration to cache key-value pair without prefix and return value without key


### How was it tested?

- Fix test to check the key as well
