### PR TITLE
Edit to fix increacing memory usage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -314,6 +314,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c05aeb6a22b8f62540c194aac980f2115af067bfe15a0734d7277a768d396b31"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
+
+[[package]]
 name = "glob"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -403,9 +414,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.117"
+version = "0.2.139"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e74d72e0f9b65b5b4ca49a346af3976df0f9c61d550727f349ecd559f251a26c"
+checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
 
 [[package]]
 name = "libloading"
@@ -461,6 +472,7 @@ dependencies = [
  "criterion",
  "hex",
  "neon",
+ "rand 0.8.5",
  "rocksdb",
  "sha2",
  "tempdir",
@@ -627,6 +639,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -664,6 +682,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.4",
+]
+
+[[package]]
 name = "rand_core"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -677,6 +716,15 @@ name = "rand_core"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom",
+]
 
 [[package]]
 name = "rayon"
@@ -875,7 +923,7 @@ version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "15f2b5fb00ccdf689e0149d1b1b3c03fead81c2b37735d812fa8bddbbf41b6d8"
 dependencies = [
- "rand",
+ "rand 0.4.6",
  "remove_dir_all",
 ]
 
@@ -949,6 +997,12 @@ dependencies = [
  "winapi",
  "winapi-util",
 ]
+
+[[package]]
+name = "wasi"
+version = "0.11.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,9 @@ version = "0.3"
 [dependencies.bitvec]
 version = "1.0.1"
 
+[dev-dependencies.rand]
+version = "0.8.5"
+
 [dev-dependencies.criterion]
 version = "0.4.0"
 

--- a/benchmark/state_long.js
+++ b/benchmark/state_long.js
@@ -59,6 +59,7 @@ const count = 10000;
         performance.mark('c-start');
         console.log({ i, root })
         root = await db.commit(writer, i, root);
+        writer.close();
         console.log({ root })
         performance.mark('c-end');
 

--- a/src/database/reader_writer/read_writer_db.rs
+++ b/src/database/reader_writer/read_writer_db.rs
@@ -300,4 +300,16 @@ impl ReadWriter {
 
         Ok(ctx.undefined())
     }
+
+    /// js_close is handler for JS ffi.
+    /// js "this" - ReadWriter.
+    pub fn js_close(mut ctx: FunctionContext) -> JsResult<JsUndefined> {
+        let db = ctx
+            .this()
+            .downcast_or_throw::<SharedReadWriter, _>(&mut ctx)?;
+        let db = db.borrow_mut();
+        db.close().or_else(|err| ctx.throw_error(err.to_string()))?;
+
+        Ok(ctx.undefined())
+    }
 }

--- a/src/database/reader_writer/reader_base.rs
+++ b/src/database/reader_writer/reader_base.rs
@@ -19,7 +19,6 @@ pub struct ReaderBase {
 
 impl Finalize for ReaderBase {
     fn finalize<'a, C: Context<'a>>(self, _: &mut C) {
-        self.close().unwrap();
         drop(self);
     }
 }
@@ -55,7 +54,7 @@ impl ReaderBase {
 
     /// Idiomatic rust would take an owned `self` to prevent use after close
     /// However, it's not possible to prevent JavaScript from continuing to hold a closed database
-    fn close(&self) -> Result<(), mpsc::SendError<SnapshotMessage>> {
+    pub fn close(&self) -> Result<(), mpsc::SendError<SnapshotMessage>> {
         self.tx.send(SnapshotMessage::Close)
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,6 +52,7 @@ fn main(mut cx: ModuleContext) -> NeonResult<()> {
     cx.export_function("state_db_reader_iterate", reader_db::Reader::js_iterate)?;
 
     cx.export_function("state_db_read_writer_new", ReadWriter::js_new)?;
+    cx.export_function("state_db_read_writer_close", ReadWriter::js_close)?;
     cx.export_function("state_db_read_writer_upsert_key", ReadWriter::js_upsert_key)?;
     cx.export_function("state_db_read_writer_get_key", ReadWriter::js_get_key)?;
     cx.export_function("state_db_read_writer_delete", ReadWriter::js_delete_key)?;
@@ -79,6 +80,7 @@ fn main(mut cx: ModuleContext) -> NeonResult<()> {
     let state_writer_new = StateWriter::js_new_with_arc_mutex::<StateWriter>;
     let restore_snapshot = StateWriter::js_restore_snapshot;
     cx.export_function("state_writer_new", state_writer_new)?;
+    cx.export_function("state_writer_close", StateWriter::js_close)?;
     cx.export_function("state_writer_snapshot", StateWriter::js_snapshot)?;
     cx.export_function("state_writer_restore_snapshot", restore_snapshot)?;
 

--- a/src/sparse_merkle_tree/smt.rs
+++ b/src/sparse_merkle_tree/smt.rs
@@ -505,14 +505,12 @@ impl UpdateData {
     pub fn new_with_hash(data: Cache) -> Self {
         let mut new_data = Cache::new();
         for (k, v) in data {
+            let mut value: Vec<u8> = vec![];
             if !v.is_empty() {
-                new_data.insert(
-                    k.hash_with_kind(HashKind::Key),
-                    v.hash_with_kind(HashKind::Value),
-                );
-            } else {
-                new_data.insert(k.hash_with_kind(HashKind::Key), vec![]);
+                value = v.hash_with_kind(HashKind::Value);
             }
+            let key = k.hash_with_kind(HashKind::Key);
+            new_data.insert(key, value);
         }
         Self { data: new_data }
     }

--- a/state_db.js
+++ b/state_db.js
@@ -28,6 +28,7 @@ const {
     state_db_checkpoint,
     state_db_calculate_root,
     state_writer_new,
+    state_writer_close,
     state_writer_snapshot,
     state_writer_restore_snapshot,
     state_db_reader_new,
@@ -35,6 +36,7 @@ const {
     state_db_reader_exists,
     state_db_reader_iterate,
     state_db_read_writer_new,
+    state_db_read_writer_close,
     state_db_read_writer_upsert_key,
     state_db_read_writer_get_key,
     state_db_read_writer_delete,
@@ -98,6 +100,11 @@ class StateReadWriter {
 
     get writer() {
         return this._writer;
+    }
+
+    close() {
+        state_db_read_writer_close.call(this._db);
+        state_writer_close.call(this.writer);
     }
 
     async get(key) {

--- a/test/statedb.spec.js
+++ b/test/statedb.spec.js
@@ -452,6 +452,15 @@ describe('statedb', () => {
                 await writer.set(initState[1].key, getRandomBytes());
                 expect(() => writer.restoreSnapshot(99)).toThrow('Invalid usage');
             });
+
+            it('should throw an error when the writer is closed', async () => {
+                const writer = db.newReadWriter();
+                const newValue = getRandomBytes();
+                await writer.set(initState[1].key, newValue);
+                await expect(writer.get(initState[1].key)).resolves.toEqual(newValue);
+                writer.close();
+                expect(() => writer.get(initState[1].key)).rejects.toThrow();
+            });
         });
 
         describe('StateReader', () => {

--- a/types.d.ts
+++ b/types.d.ts
@@ -86,6 +86,7 @@ declare class StateReadWriter {
     range(options?: IterateOptions): Promise<{ key: Buffer, value: Buffer }[]>;
     snapshot(): number;
     restoreSnapshot(index: number): void;
+    close(): void;
 }
 
 interface StateCommitOption {


### PR DESCRIPTION
### What was the problem?

- This PR resolves memory increment which is described in issue #88
- There is some memory leaks on `instruments` so the issue should be still open.

### How was it solved?

- Implement `close` functions for `ReadWriter` to close the connection.
- Define an empty function for  `StateWriter` to call it from JS.
- Finally implement `close` function for `StateReadWriter` in `state_db.js` to release the memory.

### How was it tested?

- Add a new unit test to check close function in JS.
- Also add a new unit test to check multi_thread usage for StateWriter.
- All tests passed.

### Additional info:

- The result of the `Instruments` for `state_long.js` shows memory usage will be drop when GC is running by JS.
- It depends on the running machine (also the number of iterations for `inner` and `outer` loops) but it should be remain fixed during the execution when the GC is called.
