### PR TITLE
Fix install not to build from scratch

### DIFF
--- a/install.js
+++ b/install.js
@@ -1,6 +1,6 @@
 const shell = require("shelljs");
  
-shell.exec(`npx node-pre-gyp install --build-from-source`);
+shell.exec("npx node-pre-gyp install");
 if (shell.error()) {
     shell.exec("yarn install --ignore-scripts");
     shell.exec("yarn clean");


### PR DESCRIPTION
### Description

This PR resolves #96 


- Remove the build flag to fetch the pre built binary