### PR TITLE
Update build tools to be in dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,14 +37,14 @@
   },
   "dependencies": {
     "@mapbox/node-pre-gyp": "^1.0.9",
-    "@types/node": "^16"
+    "@types/node": "^16",
+    "cargo-cp-artifact": "^0.1",
+    "shelljs": "^0.8.5"
   },
   "devDependencies": {
     "bunyan": "^1.8.15",
-    "cargo-cp-artifact": "^0.1",
     "jest": "^27.5.1",
     "rimraf": "^3.0.2",
-    "shelljs": "^0.8.5",
     "sodium-native": "^3.3.0"
   },
   "binary": {


### PR DESCRIPTION
### Description

This PR resolves #97 

- Move the build tools to be in dependencies in case it needs to build on install