### PR TITLE
Fix proof verification for zero append bitmap

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,11 @@
+### What was the problem?
+
+This PR resolves #INSERT_ISSUE_NUMBER
+
+### How was it solved?
+
+<!--- Please describe your technical implementation -->
+
+### How was it tested?
+
+<!--- Please describe how you tested your changes -->

--- a/src/sparse_merkle_tree/in_memory_smt.rs
+++ b/src/sparse_merkle_tree/in_memory_smt.rs
@@ -343,8 +343,15 @@ impl InMemorySMT {
             channel.send(move |mut ctx| {
                 let callback = callback.into_inner(&mut ctx);
                 let this = ctx.undefined();
-                let buffer = JsBuffer::external(&mut ctx, result);
-                let args: Vec<Handle<JsValue>> = vec![ctx.null().upcast(), buffer.upcast()];
+                let args: Vec<Handle<JsValue>> = match result {
+                    Ok(val) => {
+                        vec![
+                            ctx.null().upcast(),
+                            JsBuffer::external(&mut ctx, val).upcast(),
+                        ]
+                    },
+                    Err(err) => vec![ctx.error(err.to_string())?.upcast()],
+                };
                 callback.call(&mut ctx, this, args)?;
 
                 Ok(())

--- a/src/sparse_merkle_tree/smt.rs
+++ b/src/sparse_merkle_tree/smt.rs
@@ -1394,12 +1394,9 @@ impl SparseMerkleTree {
             if !sorted_queries.is_empty() && query.is_sibling_of(&sorted_queries[0]) {
                 let sibling = sorted_queries.pop_front().unwrap();
                 sibling_hash = Some(sibling.hash);
-            } else if !query.binary_bitmap[0] {
+            } else if !query.binary_bitmap[0] || sibling_hashes.len() == next_sibling_hash {
                 sibling_hash = Some(EMPTY_HASH.to_vec());
             } else if query.binary_bitmap[0] {
-                if sibling_hashes.len() == next_sibling_hash {
-                    return query.hash.clone();
-                }
                 sibling_hash = Some(sibling_hashes[next_sibling_hash].clone());
                 next_sibling_hash += 1;
             }

--- a/src/sparse_merkle_tree/smt.rs
+++ b/src/sparse_merkle_tree/smt.rs
@@ -860,11 +860,11 @@ impl SparseMerkleTree {
                 return false;
             }
             let query = &proof.queries[i];
+            if query.bitmap.len() > 0 && (query.bitmap[0] == 0 || query.bitmap[query.bitmap.len() - 1] == 0) {
+                return false;
+            }
             if utils::is_bytes_equal(key, query.key()) {
                 continue;
-            }
-            if query.bitmap.len() > 0 && query.bitmap[0] == 0 {
-                return false;
             }
             let key_binary = utils::bytes_to_bools(key);
             let query_key_binary = utils::bytes_to_bools(query.key());

--- a/src/sparse_merkle_tree/smt.rs
+++ b/src/sparse_merkle_tree/smt.rs
@@ -1399,7 +1399,7 @@ impl SparseMerkleTree {
             } else if query.binary_bitmap[0] {
                 if sibling_hashes.len() == next_sibling_hash {
                     return Err(SMTError::InvalidInput(String::from(
-                        "length of sibnling_hashes does not match with bitmap",
+                        "no more sibling hashes available",
                     )));
                 }
                 sibling_hash = Some(sibling_hashes[next_sibling_hash].clone());

--- a/src/sparse_merkle_tree/smt.rs
+++ b/src/sparse_merkle_tree/smt.rs
@@ -1377,7 +1377,7 @@ impl SparseMerkleTree {
     pub fn calculate_root(
         sibling_hashes: &[Vec<u8>],
         queries: &mut [QueryProofWithProof],
-    ) -> Vec<u8> {
+    ) -> Result<Vec<u8>, SMTError> {
         queries.sort_descending();
 
         let mut sorted_queries = VecDeque::from(queries.to_vec());
@@ -1386,7 +1386,7 @@ impl SparseMerkleTree {
         while !sorted_queries.is_empty() {
             let query = &sorted_queries.pop_front().unwrap();
             if query.is_zero_height() {
-                return query.hash.clone();
+                return Ok(query.hash.clone());
             }
 
             let mut sibling_hash: VecOption = None;
@@ -1394,9 +1394,14 @@ impl SparseMerkleTree {
             if !sorted_queries.is_empty() && query.is_sibling_of(&sorted_queries[0]) {
                 let sibling = sorted_queries.pop_front().unwrap();
                 sibling_hash = Some(sibling.hash);
-            } else if !query.binary_bitmap[0] || sibling_hashes.len() == next_sibling_hash {
+            } else if !query.binary_bitmap[0] {
                 sibling_hash = Some(EMPTY_HASH.to_vec());
             } else if query.binary_bitmap[0] {
+                if sibling_hashes.len() == next_sibling_hash {
+                    return Err(SMTError::InvalidInput(String::from(
+                        "length of sibnling_hashes does not match with bitmap",
+                    )));
+                }
                 sibling_hash = Some(sibling_hashes[next_sibling_hash].clone());
                 next_sibling_hash += 1;
             }
@@ -1415,7 +1420,7 @@ impl SparseMerkleTree {
             insert_and_filter_queries(next_query, &mut sorted_queries);
         }
 
-        vec![]
+        Ok(vec![])
     }
 
     /// new creates a new SparseMerkleTree.
@@ -1507,10 +1512,10 @@ impl SparseMerkleTree {
             .cloned()
             .collect::<Vec<QueryProofWithProof>>();
 
-        Ok(utils::is_bytes_equal(
-            root,
-            &SparseMerkleTree::calculate_root(&proof.sibling_hashes, &mut filtered_proof),
-        ))
+        match SparseMerkleTree::calculate_root(&proof.sibling_hashes, &mut filtered_proof) {
+            Ok(computed_root) => Ok(utils::is_bytes_equal(root, &computed_root)),
+            Err(_) => Ok(false),
+        }
     }
 }
 

--- a/src/sparse_merkle_tree/smt.rs
+++ b/src/sparse_merkle_tree/smt.rs
@@ -860,7 +860,7 @@ impl SparseMerkleTree {
                 return false;
             }
             let query = &proof.queries[i];
-            if query.bitmap.len() > 0 && (query.bitmap[0] == 0 || query.bitmap[query.bitmap.len() - 1] == 0) {
+            if query.bitmap.len() > 0 && query.bitmap[0] == 0 {
                 return false;
             }
             if utils::is_bytes_equal(key, query.key()) {
@@ -1397,6 +1397,9 @@ impl SparseMerkleTree {
             } else if !query.binary_bitmap[0] {
                 sibling_hash = Some(EMPTY_HASH.to_vec());
             } else if query.binary_bitmap[0] {
+                if sibling_hashes.len() == next_sibling_hash {
+                    return query.hash.clone();
+                }
                 sibling_hash = Some(sibling_hashes[next_sibling_hash].clone());
                 next_sibling_hash += 1;
             }

--- a/src/sparse_merkle_tree/smt.rs
+++ b/src/sparse_merkle_tree/smt.rs
@@ -863,6 +863,9 @@ impl SparseMerkleTree {
             if utils::is_bytes_equal(key, query.key()) {
                 continue;
             }
+            if query.bitmap.len() > 0 && query.bitmap[0] == 0 {
+                return false;
+            }
             let key_binary = utils::bytes_to_bools(key);
             let query_key_binary = utils::bytes_to_bools(query.key());
             let common_prefix = utils::common_prefix(&key_binary, &query_key_binary);

--- a/src/state/state_db.rs
+++ b/src/state/state_db.rs
@@ -808,8 +808,15 @@ impl StateDB {
             channel.send(move |mut ctx| {
                 let callback = callback.into_inner(&mut ctx);
                 let this = ctx.undefined();
-                let buffer = JsBuffer::external(&mut ctx, result);
-                let args: Vec<Handle<JsValue>> = vec![ctx.null().upcast(), buffer.upcast()];
+                let args: Vec<Handle<JsValue>> = match result {
+                    Ok(val) => {
+                        vec![
+                            ctx.null().upcast(),
+                            JsBuffer::external(&mut ctx, val).upcast(),
+                        ]
+                    },
+                    Err(err) => vec![ctx.error(err.to_string())?.upcast()],
+                };
                 callback.call(&mut ctx, this, args)?;
 
                 Ok(())

--- a/test/sparse_merkle_tree.spec.js
+++ b/test/sparse_merkle_tree.spec.js
@@ -176,6 +176,24 @@ describe('SparseMerkleTree', () => {
 				expect(siblingHashesString).toEqual(outputProof.siblingHashes);
 				expect(queriesString).toEqual(outputProof.queries);
 				await expect(smt.verify(Buffer.from(outputMerkleRoot, 'hex'), queryKeys, proof)).resolves.toEqual(true);
+
+				// modified bitmap should fail
+				const zeroPrependedProof =  {
+					...proof,
+					queries: proof.queries.map(q => ({
+						...q,
+						bitmap: Buffer.concat([Buffer.from([0]), q.bitmap])
+					})),
+				};
+				await expect(smt.verify(Buffer.from(outputMerkleRoot, 'hex'), queryKeys, zeroPrependedProof)).resolves.toEqual(false);
+				const zeroAppendedProof =  {
+					...proof,
+					queries: proof.queries.map(q => ({
+						...q,
+						bitmap: Buffer.concat([q.bitmap, Buffer.from([0])])
+					})),
+				};
+				await expect(smt.verify(Buffer.from(outputMerkleRoot, 'hex'), queryKeys, zeroAppendedProof)).resolves.toEqual(false);
 			});
 		}
 	});


### PR DESCRIPTION
### What was the problem?

This PR resolves #99 

### How was it solved?

- Add check on `verify_query_keys`

### How was it tested?

- Added unit test to verify zero byte append and prepend bitmap proof