### PR TITLE
Fix iterator function not to be called multiple times

### DIFF
--- a/benchmark/iterator.js
+++ b/benchmark/iterator.js
@@ -1,0 +1,41 @@
+const { Database } = require("../main");
+const crypto = require('crypto');
+
+const getRandomBytes = (num = 32) => crypto.randomBytes(num);
+
+(async () => {
+    const db = new Database('.tmp', { readonly: false });
+
+    const keys = [];
+    for (let i = 0; i < 1000; i++) {
+        const key = getRandomBytes();
+        await db.set(key, getRandomBytes(100))
+        keys.push(key);
+    }
+
+    for (let i = 0; i < 1000; i++) {
+        console.log('key', keys.length)
+        console.time('get');
+        const stream = await db.iterate({ limit: 1000 });
+        const blockIDs = await new Promise((resolve, reject) => {
+			const ids = [];
+			stream
+				.on('data', ({ value }) => {
+					ids.push(value);
+				})
+				.on('error', error => {
+					reject(error);
+				})
+				.on('end', () => {
+					resolve(ids);
+				});
+		});
+        console.log('*'.repeat(100));
+        console.log(blockIDs.length)
+        console.timeEnd('get');
+    }
+    console.log('done')
+
+    await db.close();
+
+})()

--- a/database.js
+++ b/database.js
@@ -207,9 +207,6 @@ class InMemoryIterator extends Readable {
         this._db = db;
         this._options = options;
         Readable.call(this, { objectMode: true });
-    }
-
-    _read() {
         in_memory_db_iterate.call(
             this._db,
             this._options,
@@ -224,6 +221,9 @@ class InMemoryIterator extends Readable {
                 this.push(null)
             },
         );
+    }
+
+    _read() {
     }
 }
 

--- a/iterator.js
+++ b/iterator.js
@@ -23,9 +23,6 @@ class Iterator extends Readable {
         this._options = options;
         this.queue = []
         Readable.call(this, { objectMode: true });
-    }
-
-    _read() {
         this._iterateFunc.call(
             this._db,
             this._options,
@@ -40,6 +37,9 @@ class Iterator extends Readable {
                 this.push(null);
             },
         );
+    }
+
+    _read() {
     }
 }
 

--- a/test/database.spec.js
+++ b/test/database.spec.js
@@ -295,7 +295,79 @@ describe('database', () => {
                 });
 
                 it('should iterate with specified range with limit', async () => {
+                    const stream = db.iterate({
+                        gte: Buffer.from([0, 0, 1]),
+                        lte: Buffer.from([1, 0, 1]),
+                        limit: 2,
+                    });
+
+                    const values = await new Promise((resolve, reject) => {
+                        const result = [];
+                        stream
+                            .on('data', kv => {
+                                result.push(kv);
+                            })
+                            .on('err', err => {
+                                reject(err);
+                            })
+                            .on('end', () => {
+                                resolve(result);
+                            });
+                    });
+
+                    expect(values).toEqual(pairs.slice(1, 3));
+                });
+
+                it('should iterate with specified range with limit using createReadStream', async () => {
+                    const stream = db.createReadStream({
+                        gte: Buffer.from([0, 0, 1]),
+                        lte: Buffer.from([1, 0, 1]),
+                        limit: 2,
+                    });
+
+                    const values = await new Promise((resolve, reject) => {
+                        const result = [];
+                        stream
+                            .on('data', kv => {
+                                result.push(kv);
+                            })
+                            .on('err', err => {
+                                reject(err);
+                            })
+                            .on('end', () => {
+                                resolve(result);
+                            });
+                    });
+
+                    expect(values).toEqual(pairs.slice(1, 3));
+                });
+
+                it('should iterate with specified range with limit with reader', async () => {
                     const stream = db.newReader().iterate({
+                        gte: Buffer.from([0, 0, 1]),
+                        lte: Buffer.from([1, 0, 1]),
+                        limit: 2,
+                    });
+
+                    const values = await new Promise((resolve, reject) => {
+                        const result = [];
+                        stream
+                            .on('data', kv => {
+                                result.push(kv);
+                            })
+                            .on('err', err => {
+                                reject(err);
+                            })
+                            .on('end', () => {
+                                resolve(result);
+                            });
+                    });
+
+                    expect(values).toEqual(pairs.slice(1, 3));
+                });
+
+                it('should iterate with specified range with limit using createReadStream', async () => {
+                    const stream = db.newReader().createReadStream({
                         gte: Buffer.from([0, 0, 1]),
                         lte: Buffer.from([1, 0, 1]),
                         limit: 2,
@@ -503,6 +575,30 @@ describe('database', () => {
 
             it('should iterate with specified range with limit', async () => {
                 const stream = db.iterate({
+                    gte: Buffer.from([0, 0, 1]),
+                    lte: Buffer.from([1, 0, 1]),
+                    limit: 2,
+                });
+
+                const values = await new Promise((resolve, reject) => {
+                    const result = [];
+                    stream
+                        .on('data', kv => {
+                            result.push(kv);
+                        })
+                        .on('err', err => {
+                            reject(err);
+                        })
+                        .on('end', () => {
+                            resolve(result);
+                        });
+                });
+
+                expect(values).toEqual(pairs.slice(1, 3));
+            });
+
+            it('should iterate with specified range with limit using createReadStream', async () => {
+                const stream = db.createReadStream({
                     gte: Buffer.from([0, 0, 1]),
                     lte: Buffer.from([1, 0, 1]),
                     limit: 2,


### PR DESCRIPTION
### What was the problem?

This PR resolves #103 

### How was it solved?

- Remove logic from `_read` and move to constructor because `_read` will be called for number of times data is emitted.

### How was it tested?

- Run the iterator benchmark (node benchmark/iterator.js)
- All tests should pass
