### PR TITLE
Fix `common_prefix` method

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -80,6 +80,8 @@ pub fn common_prefix(a: &[bool], b: &[bool]) -> Vec<bool> {
         }
         if *v == shorter[i] {
             result.push(*v);
+        } else {
+            return result;
         }
     }
     result
@@ -268,6 +270,16 @@ mod tests {
             (
                 vec![true, false],
                 vec![true, false, true],
+                vec![true, false],
+            ),
+            (
+                vec![true, false, true, true],
+                vec![true, true, true, true],
+                vec![true],
+            ),
+            (
+                vec![true, false, false, true, false],
+                vec![true, false, true, true, false],
                 vec![true, false],
             ),
         ];


### PR DESCRIPTION
### What was the problem?

- This PR resolves #105.

### How was it solved?

- Missing return statement in `common_prefix` function was added.

### How was it tested?

- New unit tests were added.
- All previous unit tests passed.
