### PR TITLE
Fix `common_prefix` method

### DIFF
--- a/src/state/state_writer.rs
+++ b/src/state/state_writer.rs
@@ -298,8 +298,10 @@ mod tests {
 
     #[test]
     fn test_multi_thread() {
-        let outer_loop_iterations = 1000;
-        let inner_loop_iteration = 2000;
+        // On some machines, while executing this unit test, it could occur buffer overflow or out of memory error.
+        // Because of that reason, we limit the number of iterations.
+        let outer_loop_iterations = 100;
+        let inner_loop_iteration = 200;
         let pairs_len = inner_loop_iteration / 10;
 
         for _ in 0..outer_loop_iterations {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -80,6 +80,8 @@ pub fn common_prefix(a: &[bool], b: &[bool]) -> Vec<bool> {
         }
         if *v == shorter[i] {
             result.push(*v);
+        } else {
+            return result;
         }
     }
     result
@@ -268,6 +270,16 @@ mod tests {
             (
                 vec![true, false],
                 vec![true, false, true],
+                vec![true, false],
+            ),
+            (
+                vec![true, false, true, true],
+                vec![true, true, true, true],
+                vec![true],
+            ),
+            (
+                vec![true, false, false, true, false],
+                vec![true, false, true, true, false],
                 vec![true, false],
             ),
         ];


### PR DESCRIPTION
### What was the problem?

- This PR resolves #105.
- Decrease loop iterations for `test_multi_thread` unit test.

### How was it solved?

- Missing return statement in `common_prefix` function was added.
- On some machines while executing `test_multi_thread` unit test it could occur buffer overflow or out of memory error. Because of that loop iterations were decreased.

### How was it tested?

- New unit tests were added.
- All previous unit tests passed.
