### PR TITLE
Support Node.js 16 and 18

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -15,8 +15,7 @@ jobs:
         rust_version:
         - stable
         # - beta
-        node_version:
-        - 16
+        node_version: [16, 18]
         architecture:
         - x64
         system:
@@ -34,6 +33,15 @@ jobs:
             - ARM64
             target: aarch64-apple-darwin
           node_version: 16
+          architecture: arm64
+          rust_version: stable-aarch64-apple-darwin
+        - system:
+            os:
+            - self-hosted
+            - macOS
+            - ARM64
+            target: aarch64-apple-darwin
+          node_version: 18
           architecture: arm64
           rust_version: stable-aarch64-apple-darwin
 
@@ -69,7 +77,7 @@ jobs:
     - name: Run node.js tests
       run: yarn run test:node
     - name: Check test coverage
-      if: ${{ contains(matrix.system.os, 'ubuntu') && matrix.node_version == '16'
+      if: ${{ contains(matrix.system.os, 'ubuntu') && matrix.node_version == '18'
         && matrix.rust_version == 'stable' && github.base_ref != '' }}
       uses: anuraag016/Jest-Coverage-Diff@V1.4
       with:

--- a/.github/workflows/publish-canary.yaml
+++ b/.github/workflows/publish-canary.yaml
@@ -21,8 +21,7 @@ jobs:
       matrix:
         rust_version:
           - stable
-        node_version:
-          - 16
+        node_version: [16, 18]
         architecture:
           - x64
         system:
@@ -33,11 +32,17 @@ jobs:
           - os: windows-latest
             target: x86_64-pc-windows-msvc
         include:
-          # only node 15+ supports arm64 natively, so we only need to build 16 for now
+          # only node 15+ supports arm64 natively, so we only need to build 16 and 18 for now
           - system:
               os: [self-hosted, macOS, ARM64]
               target: aarch64-apple-darwin
             node_version: 16
+            architecture: arm64
+            rust_version: stable-aarch64-apple-darwin 
+          - system:
+              os: [self-hosted, macOS, ARM64]
+              target: aarch64-apple-darwin
+            node_version: 18
             architecture: arm64
             rust_version: stable-aarch64-apple-darwin 
     steps:
@@ -95,7 +100,7 @@ jobs:
       - uses: c-hive/gha-yarn-cache@v1
       - uses: actions/setup-node@v2.1.5
         with:
-          node-version: 16
+          node-version: [16, 18]
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -22,8 +22,7 @@ jobs:
       matrix:
         rust_version:
           - stable
-        node_version:
-          - 16
+        node_version: [16, 18]
         architecture:
           - x64
         system:
@@ -34,11 +33,17 @@ jobs:
           - os: windows-latest
             target: x86_64-pc-windows-msvc
         include:
-          # only node 15+ supports arm64 natively, so we only need to build 16 for now
+          # only node 15+ supports arm64 natively, so we only need to build 16 and 18 for now
           - system:
               os: [self-hosted, macOS, ARM64]
               target: aarch64-apple-darwin
             node_version: 16
+            architecture: arm64
+            rust_version: stable-aarch64-apple-darwin 
+          - system:
+              os: [self-hosted, macOS, ARM64]
+              target: aarch64-apple-darwin
+            node_version: 18
             architecture: arm64
             rust_version: stable-aarch64-apple-darwin 
     steps:

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   },
   "dependencies": {
     "@mapbox/node-pre-gyp": "^1.0.9",
-    "@types/node": "^16",
+    "@types/node": "^16 || ^18",
     "cargo-cp-artifact": "^0.1",
     "shelljs": "^0.8.5"
   },

--- a/test/database.spec.js
+++ b/test/database.spec.js
@@ -447,9 +447,6 @@ describe('database', () => {
             beforeEach(() => {
                 tmpPath = fs.mkdtempSync("");
             });
-            afterEach(() => {
-                fs.rmSync(tmpPath, { recursive: true, force: true });
-            });
 
             it('should create checkpoint', async () => {
                 const pairs = [

--- a/test/statedb.spec.js
+++ b/test/statedb.spec.js
@@ -559,9 +559,6 @@ describe('statedb', () => {
             beforeEach(() => {
                 tmpPath = fs.mkdtempSync("");
             });
-            afterEach(() => {
-                fs.rmSync(tmpPath, { recursive: true, force: true });
-            });
 
             it('should create checkpoint', async () => {
                 await expect(db.get(initState[0].key)).resolves.toEqual(initState[0].value);

--- a/yarn.lock
+++ b/yarn.lock
@@ -600,10 +600,10 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-17.0.31.tgz#a5bb84ecfa27eec5e1c802c6bbf8139bdb163a5d"
   integrity sha512-AR0x5HbXGqkEx9CadRH3EBYx/VkiUgZIhP4wvPn/+5KIsgpNoyFaRlVe0Zlx9gRtg8fA06a9tskE2MSN7TcG4Q==
 
-"@types/node@^16":
-  version "16.11.33"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-16.11.33.tgz#566713b1b626f781c5c58fe3531307283e00720c"
-  integrity sha512-0PJ0vg+JyU0MIan58IOIFRtSvsb7Ri+7Wltx2qAg94eMOrpg4+uuP3aUHCpxXc1i0jCXiC+zIamSZh3l9AbcQA==
+"@types/node@^16 || ^18":
+  version "18.16.10"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.16.10.tgz#9b16d918f4f6fec6cae4af34283a91d555b81519"
+  integrity sha512-sMo3EngB6QkMBlB9rBe1lFdKSLqljyWPPWv6/FzSxh/IDlyVWSzE9RiF4eAuerQHybrWdqBgAGb03PM89qOasA==
 
 "@types/prettier@^2.1.5":
   version "2.6.0"


### PR DESCRIPTION
### What was the problem?

This PR resolves #90.

### How was it solved?

- `package.json` was updated to support both Node.js 16 and 18.
- GitHub workflows were updated to use Node.js 16 and 18 for builds.
- Removed unnecessary directory cleanup after some JS unit test executions.

### How was it tested?

All tests passed.
