### PR TITLE
Fixed canary build for Node.js 16 and 18

### DIFF
--- a/.github/workflows/publish-canary.yaml
+++ b/.github/workflows/publish-canary.yaml
@@ -100,7 +100,7 @@ jobs:
       - uses: c-hive/gha-yarn-cache@v1
       - uses: actions/setup-node@v2.1.5
         with:
-          node-version: [16, 18]
+          node-version: 18
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal


### PR DESCRIPTION
### What was the problem?

A bug for canary build was introduced within PR #113 for issue #90.

### How was it solved?

When publishing `npm` only `Node.js` 18 is used.

### How was it tested?

Canary workflow successfully passed.
